### PR TITLE
Spotify 데이터 처리 성능개선 및 테스트 커버리지 강화

### DIFF
--- a/src/main/java/com/example/spotify_song_subject/application/AlbumBatchProcessor.java
+++ b/src/main/java/com/example/spotify_song_subject/application/AlbumBatchProcessor.java
@@ -1,0 +1,161 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.Album;
+import com.example.spotify_song_subject.repository.AlbumRepository;
+import com.example.spotify_song_subject.repository.bulk.AlbumBulkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Album 배치 처리를 담당하는 전용 프로세서
+ * 개별 save 대신 bulk insert를 사용하도록 최적화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlbumBatchProcessor {
+
+    private final AlbumRepository albumRepository;
+    private final AlbumBulkRepository albumBulkRepository;
+
+    /**
+     * Albums 배치 처리 - Bulk Insert 최적화 버전
+     * 1. 기존 앨범 조회
+     * 2. 새 앨범 필터링
+     * 3. Bulk Insert
+     */
+    public Mono<Map<String, Album>> processAlbumsBatch(Map<String, Set<AlbumInfo>> albumsByTitle) {
+        if (albumsByTitle.isEmpty()) {
+            return Mono.just(Collections.emptyMap());
+        }
+
+        List<AlbumKey> albumKeys = buildAlbumKeys(albumsByTitle);
+        return findExistingAlbums(albumKeys)
+            .flatMap(existingAlbums -> insertNewAlbums(albumKeys, existingAlbums))
+            .map(this::createAlbumMap);
+    }
+
+    /**
+     * AlbumKey 생성 - title, releaseDate, artistName의 조합
+     */
+    private List<AlbumKey> buildAlbumKeys(Map<String, Set<AlbumInfo>> albumsByTitle) {
+        List<AlbumKey> albumKeys = new ArrayList<>();
+
+        for (Map.Entry<String, Set<AlbumInfo>> entry : albumsByTitle.entrySet()) {
+            String title = entry.getKey();
+            for (AlbumInfo info : entry.getValue()) {
+                albumKeys.add(new AlbumKey(title, info.releaseDate(), info.artistName()));
+            }
+        }
+
+        return albumKeys;
+    }
+
+    /**
+     * 기존 앨범 조회 - IN 절을 사용한 최적화
+     */
+    private Mono<Map<AlbumKey, Album>> findExistingAlbums(List<AlbumKey> albumKeys) {
+        if (albumKeys.isEmpty()) {
+            return Mono.just(Collections.emptyMap());
+        }
+
+        Set<String> titles = albumKeys.stream()
+            .map(AlbumKey::title)
+            .collect(Collectors.toSet());
+
+        return albumRepository.findAllByTitleIn(titles)
+            .collectList()
+            .map(albums -> {
+                Map<String, Album> albumsByKey = new HashMap<>();
+                for (Album album : albums) {
+                    String dbKey = album.getTitle() + "|" + album.getReleaseDate() + "|" + album.getArtistName();
+                    albumsByKey.put(dbKey, album);
+                }
+
+                Map<AlbumKey, Album> resultMap = new HashMap<>();
+                for (AlbumKey key : albumKeys) {
+                    String lookupKey = key.title() + "|" + key.releaseDate() + "|" + key.artistName();
+                    Album matchedAlbum = albumsByKey.get(lookupKey);
+                    if (matchedAlbum != null) {
+                        resultMap.put(key, matchedAlbum);
+                    }
+                }
+
+                return resultMap;
+            });
+    }
+
+    /**
+     * 새로운 앨범 일괄 삽입
+     */
+    private Mono<List<Album>> insertNewAlbums(List<AlbumKey> allKeys,
+                                              Map<AlbumKey, Album> existingAlbums) {
+
+        List<Album> newAlbums = allKeys.stream()
+            .filter(key -> !existingAlbums.containsKey(key))
+            .map(key -> Album.of(key.title(), key.releaseDate(), key.artistName()))
+            .collect(Collectors.toList());
+
+        if (newAlbums.isEmpty()) {
+            return Mono.just(new ArrayList<>(existingAlbums.values()));
+        }
+
+        return albumBulkRepository.bulkInsert(newAlbums)
+            .flatMap(count -> reloadAlbums(allKeys));
+    }
+
+    /**
+     * 모든 앨범 재조회 (삽입 후 ID 포함된 데이터 가져오기)
+     * IN 절을 사용하여 한 번에 조회
+     */
+    private Mono<List<Album>> reloadAlbums(List<AlbumKey> albumKeys) {
+        if (albumKeys.isEmpty()) {
+            return Mono.just(Collections.emptyList());
+        }
+
+        Set<String> titles = albumKeys.stream()
+            .map(AlbumKey::title)
+            .collect(Collectors.toSet());
+
+        Set<String> validKeys = albumKeys.stream()
+            .map(key -> key.title() + "|" + key.releaseDate() + "|" + key.artistName())
+            .collect(Collectors.toSet());
+
+        return albumRepository.findAllByTitleIn(titles)
+            .filter(album -> {
+                String albumKey = album.getTitle() + "|" + album.getReleaseDate() + "|" + album.getArtistName();
+                return validKeys.contains(albumKey);
+            }).collectList();
+    }
+
+    /**
+     * Album 리스트를 Map으로 변환
+     */
+    private Map<String, Album> createAlbumMap(List<Album> albums) {
+        Map<String, Album> albumMap = new HashMap<>();
+
+        for (Album album : albums) {
+            String key = album.getTitle() + "|" + album.getReleaseDate() + "|" + album.getArtistName();
+            albumMap.put(key, album);
+        }
+
+        return albumMap;
+    }
+
+    /**
+     * Album 키를 표현하는 내부 클래스
+     */
+    private record AlbumKey(String title, LocalDate releaseDate, String artistName) {}
+    
+    /**
+     * Album 정보를 표현하는 클래스
+     */
+    public record AlbumInfo(LocalDate releaseDate, String artistName) {}
+
+}

--- a/src/main/java/com/example/spotify_song_subject/application/ArtistBatchProcessor.java
+++ b/src/main/java/com/example/spotify_song_subject/application/ArtistBatchProcessor.java
@@ -1,0 +1,55 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.Artist;
+import com.example.spotify_song_subject.repository.ArtistRepository;
+import com.example.spotify_song_subject.repository.bulk.ArtistBulkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Artist 배치 처리를 담당하는 전용 프로세서
+ * 개별 save 대신 bulk insert를 사용하도록 최적화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistBatchProcessor {
+
+    private final ArtistRepository artistRepository;
+    private final ArtistBulkRepository artistBulkRepository;
+
+    /**
+     * Artists 배치 처리 - Bulk Insert 최적화 버전
+     * INSERT IGNORE를 사용하여 중복 체크를 생략하고 더 빠르게 처리 가능
+     */
+    public Mono<Map<String, Artist>> processArtistsBatch(Set<String> artistNames) {
+        if (artistNames.isEmpty()) {
+            return Mono.just(Collections.emptyMap());
+        }
+
+        return processArtistsBatchFast(artistNames);
+    }
+    
+    /**
+     * INSERT IGNORE를 활용한 빠른 배치 처리
+     * 1. 모든 아티스트를 INSERT IGNORE로 시도
+     * 2. 이후 전체 조회하여 반환
+     */
+    private Mono<Map<String, Artist>> processArtistsBatchFast(Set<String> artistNames) {
+        List<Artist> allArtists = artistNames.stream()
+            .map(Artist::of)
+            .collect(Collectors.toList());
+        
+        return artistBulkRepository.bulkInsert(allArtists)
+            .doOnNext(count -> log.debug("Attempted to insert {} artists, {} were new", 
+                allArtists.size(), count))
+            .then(artistRepository.findAllByNameIn(artistNames)
+                .collectMap(Artist::getName));
+    }
+
+}

--- a/src/main/java/com/example/spotify_song_subject/application/RelationshipDataProcessor.java
+++ b/src/main/java/com/example/spotify_song_subject/application/RelationshipDataProcessor.java
@@ -1,0 +1,221 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.*;
+import com.example.spotify_song_subject.dto.SimilarSongDto;
+import com.example.spotify_song_subject.dto.SpotifySongDto;
+import com.example.spotify_song_subject.mapper.SpotifyDomainMapper;
+import com.example.spotify_song_subject.repository.bulk.ArtistAlbumBulkRepository;
+import com.example.spotify_song_subject.repository.bulk.ArtistSongBulkRepository;
+import com.example.spotify_song_subject.repository.bulk.SimilarSongBulkRepository;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+
+/**
+ * Song과 관련된 관계 데이터를 처리하는 유틸리티 클래스
+ * ArtistSong, ArtistAlbum, SimilarSong 관계 데이터를 생성하고 관리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RelationshipDataProcessor {
+
+    private final ArtistSongBulkRepository artistSongBulkRepository;
+    private final ArtistAlbumBulkRepository artistAlbumBulkRepository;
+    private final SimilarSongBulkRepository similarSongBulkRepository;
+
+    /**
+     * Song 관계 데이터를 일괄 생성
+     */
+    @Builder
+    public record RelationshipData(List<ArtistSong> artistSongs,
+                                   List<ArtistAlbum> artistAlbums,
+                                   List<SimilarSong> similarSongs) {
+        public static RelationshipData empty() {
+            return RelationshipData.builder()
+                .artistSongs(new ArrayList<>())
+                .artistAlbums(new ArrayList<>())
+                .similarSongs(new ArrayList<>())
+                .build();
+        }
+    }
+
+    /**
+     * 저장된 Song들로부터 관계 데이터 생성
+     */
+    public static RelationshipData buildRelationships(List<Song> savedSongs,
+                                                      List<SpotifySongDto> originalDtos,
+                                                      Map<String, Artist> artistsMap,
+                                                      Map<String, Album> albumsMap,
+                                                      Map<Integer, String> songIndexToAlbumKey) {
+
+        if (savedSongs.isEmpty()) {
+            return RelationshipData.empty();
+        }
+
+        List<ArtistSong> artistSongs = new ArrayList<>();
+        List<ArtistAlbum> artistAlbums = new ArrayList<>();
+        List<SimilarSong> similarSongs = new ArrayList<>();
+        Set<String> artistAlbumKeys = new HashSet<>();
+
+        for (int i = 0; i < savedSongs.size(); i++) {
+            Song song = savedSongs.get(i);
+            SpotifySongDto dto = findOriginalDto(i, originalDtos, songIndexToAlbumKey);
+
+            if (dto == null) {
+                log.warn("Could not find original DTO for saved song at index {}", i);
+                continue;
+            }
+
+            artistSongs.addAll(buildArtistSongRelationships(song, dto, artistsMap));
+            List<ArtistAlbum> artistAlbumsItems = buildArtistAlbumRelationships(
+                dto,
+                artistsMap,
+                albumsMap,
+                songIndexToAlbumKey.get(i),
+                artistAlbumKeys
+            );
+            artistAlbums.addAll(artistAlbumsItems);
+            similarSongs.addAll(buildSimilarSongRelationships(song, dto));
+        }
+
+        return RelationshipData.builder()
+            .artistSongs(artistSongs)
+            .artistAlbums(artistAlbums)
+            .similarSongs(similarSongs)
+            .build();
+    }
+
+    /**
+     * 원본 DTO 찾기
+     */
+    private static SpotifySongDto findOriginalDto(int index,
+                                                  List<SpotifySongDto> originalDtos,
+                                                  Map<Integer, String> songIndexToAlbumKey) {
+
+        Integer dtoIndex = songIndexToAlbumKey.keySet().stream()
+            .filter(songIndexToAlbumKey::containsKey)
+            .skip(index)
+            .findFirst()
+            .orElse(index);
+
+        if (dtoIndex >= 0 && dtoIndex < originalDtos.size()) {
+            return originalDtos.get(dtoIndex);
+        }
+
+        return null;
+    }
+
+    /**
+     * ArtistSong 관계 생성
+     */
+    private static List<ArtistSong> buildArtistSongRelationships(Song song,
+                                                                 SpotifySongDto dto,
+                                                                 Map<String, Artist> artistsMap) {
+
+        List<ArtistSong> artistSongs = new ArrayList<>();
+        List<Artist> artists = SpotifyDomainMapper.extractArtists(dto);
+
+        for (Artist artistDto : artists) {
+            Artist artist = artistsMap.get(artistDto.getName());
+            if (artist != null) {
+                ArtistSong artistSong = SpotifyDomainMapper.createArtistSong(artist.getId(), song.getId());
+                artistSongs.add(artistSong);
+            }
+        }
+
+        return artistSongs;
+    }
+
+    /**
+     * ArtistAlbum 관계 생성 (중복 제거 포함)
+     */
+    private static List<ArtistAlbum> buildArtistAlbumRelationships(SpotifySongDto dto,
+                                                                   Map<String, Artist> artistsMap,
+                                                                   Map<String, Album> albumsMap,
+                                                                   String albumKey,
+                                                                   Set<String> artistAlbumKeys) {
+        List<ArtistAlbum> artistAlbums = new ArrayList<>();
+        if (albumKey == null) {
+            return artistAlbums;
+        }
+
+        Album album = albumsMap.get(albumKey);
+        if (album == null) {
+            return artistAlbums;
+        }
+
+        List<Artist> artists = SpotifyDomainMapper.extractArtists(dto);
+
+        for (Artist artistDto : artists) {
+            Artist artist = artistsMap.get(artistDto.getName());
+            if (artist != null) {
+                String uniqueKey = artist.getId() + "-" + album.getId();
+                if (artistAlbumKeys.add(uniqueKey)) {
+                    ArtistAlbum artistAlbum = SpotifyDomainMapper.createArtistAlbum(artist.getId(), album.getId());
+                    artistAlbums.add(artistAlbum);
+                }
+            }
+        }
+
+        return artistAlbums;
+    }
+
+    /**
+     * SimilarSong 관계 생성
+     */
+    private static List<SimilarSong> buildSimilarSongRelationships(Song song,
+                                                                   SpotifySongDto dto) {
+        List<SimilarSong> similarSongs = new ArrayList<>();
+        if (dto.getSimilarSongs() == null || dto.getSimilarSongs().isEmpty()) {
+            return similarSongs;
+        }
+
+        for (SimilarSongDto similar : dto.getSimilarSongs()) {
+            SimilarSong similarSong = SpotifyDomainMapper.createSimilarSong(
+                song.getId(),
+                similar.getArtistName(),
+                similar.getSongTitle(),
+                similar.getSimilarityScore()
+            );
+
+            similarSongs.add(similarSong);
+        }
+
+        return similarSongs;
+    }
+
+    /**
+     * ArtistSong 관계 데이터를 일괄 저장
+     */
+    public Mono<Long> bulkInsertArtistSongs(Collection<ArtistSong> artistSongs) {
+        if (artistSongs.isEmpty()) {
+            return Mono.just(0L);
+        }
+        return artistSongBulkRepository.bulkInsert(artistSongs);
+    }
+
+    /**
+     * ArtistAlbum 관계 데이터를 일괄 저장
+     */
+    public Mono<Long> bulkInsertArtistAlbums(Collection<ArtistAlbum> artistAlbums) {
+        if (artistAlbums.isEmpty()) {
+            return Mono.just(0L);
+        }
+        return artistAlbumBulkRepository.bulkInsert(artistAlbums);
+    }
+
+    /**
+     * SimilarSong 관계 데이터를 일괄 저장
+     */
+    public Mono<Long> bulkInsertSimilarSongs(Collection<SimilarSong> similarSongs) {
+        if (similarSongs.isEmpty()) {
+            return Mono.just(0L);
+        }
+        return similarSongBulkRepository.bulkInsert(similarSongs);
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/application/SongBatchProcessor.java
+++ b/src/main/java/com/example/spotify_song_subject/application/SongBatchProcessor.java
@@ -1,0 +1,169 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.Album;
+import com.example.spotify_song_subject.domain.Song;
+import com.example.spotify_song_subject.dto.SpotifySongDto;
+import com.example.spotify_song_subject.mapper.SpotifyDomainMapper;
+import com.example.spotify_song_subject.repository.SongRepository;
+import com.example.spotify_song_subject.repository.bulk.SongBulkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Song 배치 처리를 담당하는 전용 프로세서
+ * Bulk Insert를 통한 최적화된 대량 처리 지원
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SongBatchProcessor {
+
+    private final SongRepository songRepository;
+    private final SongBulkRepository songBulkRepository;
+
+    /**
+     * Songs 배치 처리 및 저장
+     */
+    public Mono<SongProcessResult> processSongsBatch(List<SpotifySongDto> songDtos, 
+                                                     Map<String, Album> albumsMap) {
+        if (songDtos.isEmpty()) {
+            return Mono.just(new SongProcessResult(Collections.emptyList(), Collections.emptyMap()));
+        }
+
+        PreparedSongs preparedSongs = prepareSongs(songDtos, albumsMap);
+        if (preparedSongs.songs().isEmpty()) {
+            log.warn("No valid songs to process after album mapping");
+            return Mono.just(new SongProcessResult(Collections.emptyList(), Collections.emptyMap()));
+        }
+
+        return songBulkRepository.bulkInsert(preparedSongs.songs())
+            .doOnNext(count -> log.info("Bulk inserted {} songs", count))
+            .then(Mono.defer(() -> reloadSavedSongsByAlbumIds(preparedSongs.songs())))
+            .map(savedSongs -> new SongProcessResult(savedSongs, preparedSongs.songIndexToAlbumKey()));
+    }
+
+    /**
+     * Song 엔티티 준비
+     */
+    private PreparedSongs prepareSongs(List<SpotifySongDto> songDtos, 
+                                       Map<String, Album> albumsMap) {
+        List<Song> songsToSave = new ArrayList<>();
+        Map<Integer, String> songIndexToAlbumKey = new HashMap<>();
+
+        for (int i = 0; i < songDtos.size(); i++) {
+            SpotifySongDto dto = songDtos.get(i);
+            String albumKey = createAlbumKey(dto);
+            Album album = albumsMap.get(albumKey);
+
+            if (album != null) {
+                Song song = SpotifyDomainMapper.convertToSong(dto, album.getId());
+                songsToSave.add(song);
+                songIndexToAlbumKey.put(i, albumKey);
+            } else {
+                Song song = SpotifyDomainMapper.convertToSong(dto, null);
+                songsToSave.add(song);
+                songIndexToAlbumKey.put(i, null);
+            }
+        }
+
+        return new PreparedSongs(songsToSave, songIndexToAlbumKey);
+    }
+
+
+    /**
+     * 저장된 Song들을 다시 조회하여 ID 포함된 객체 반환
+     * title로 모든 song 조회 (album_id가 null인 것도 포함)
+     */
+    private Mono<List<Song>> reloadSavedSongsByAlbumIds(List<Song> songsToSave) {
+        if (songsToSave.isEmpty()) {
+            return Mono.just(Collections.emptyList());
+        }
+        
+        // 모든 title을 수집
+        Set<String> titles = songsToSave.stream()
+            .map(Song::getTitle)
+            .collect(Collectors.toSet());
+        
+        // title로 모든 song 조회 (album_id가 null인 것도 포함)
+        return songRepository.findAllByTitleIn(titles)
+            .collectList()
+            .map(dbSongs -> {
+                // DB에서 조회한 Song들을 키로 매핑
+                Map<String, Song> dbSongMap = new HashMap<>();
+                for (Song dbSong : dbSongs) {
+                    String key;
+                    if (dbSong.getAlbumId() != null) {
+                        key = createSongKey(dbSong.getAlbumId(), dbSong.getTitle());
+                    } else {
+                        key = "null|" + dbSong.getTitle();
+                    }
+                    dbSongMap.put(key, dbSong);
+                }
+                
+                // 저장하려던 Song들과 매칭
+                List<Song> resultSongs = new ArrayList<>();
+                for (Song savedSong : songsToSave) {
+                    String key;
+                    if (savedSong.getAlbumId() != null) {
+                        key = createSongKey(savedSong.getAlbumId(), savedSong.getTitle());
+                    } else {
+                        key = "null|" + savedSong.getTitle();
+                    }
+                    
+                    Song dbSong = dbSongMap.get(key);
+                    if (dbSong != null) {
+                        resultSongs.add(dbSong);
+                    } else {
+                        log.warn("Could not find saved song in DB: {}", savedSong.getTitle());
+                    }
+                }
+                
+                return resultSongs;
+            });
+    }
+    
+    /**
+     * Song의 고유 키 생성 (albumId + title)
+     */
+    private String createSongKey(Long albumId, String title) {
+        return albumId + "|" + title;
+    }
+    
+    /**
+     * 앨범 키 생성 (title|releaseDate|artistName)
+     */
+    private String createAlbumKey(SpotifySongDto dto) {
+        LocalDate releaseDate = SpotifyDomainMapper.parseReleaseDate(dto.getReleaseDate());
+        String artistName = extractAllArtists(dto);
+        return dto.getAlbumTitle() + "|" + releaseDate + "|" + artistName;
+    }
+    
+    /**
+     * DTO에서 전체 아티스트 이름 추출 (앨범용)
+     * 앨범에는 모든 아티스트가 포함되어야 함 (예: "A, B, C")
+     */
+    private String extractAllArtists(SpotifySongDto dto) {
+        if (dto.getArtists() == null || dto.getArtists().isEmpty()) {
+            return "Unknown Artist";
+        }
+
+        return dto.getArtists().trim();
+    }
+
+    /**
+     * Song 처리 결과
+     */
+    public record SongProcessResult(List<Song> savedSongs, Map<Integer, String> songIndexToAlbumKey) {}
+
+    /**
+     * 준비된 Songs 정보
+     */
+    private record PreparedSongs(List<Song> songs, Map<Integer, String> songIndexToAlbumKey) {}
+
+}

--- a/src/main/java/com/example/spotify_song_subject/application/SpotifyDataPersistenceService.java
+++ b/src/main/java/com/example/spotify_song_subject/application/SpotifyDataPersistenceService.java
@@ -1,193 +1,144 @@
 package com.example.spotify_song_subject.application;
 
 import com.example.spotify_song_subject.domain.*;
-import com.example.spotify_song_subject.dto.SimilarSongDto;
+import com.example.spotify_song_subject.dto.BatchContext;
 import com.example.spotify_song_subject.dto.SpotifySongDto;
 import com.example.spotify_song_subject.mapper.SpotifyDataMapper;
-import com.example.spotify_song_subject.mapper.SpotifyDomainMapper;
-import com.example.spotify_song_subject.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.reactive.TransactionalOperator;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.function.Tuple2;
 
-import java.math.BigDecimal;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Spotify 데이터를 도메인 엔티티로 변환하고 저장하는 서비스
+ * Bulk Insert 방식으로 최적화된 배치 처리 지원
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SpotifyDataPersistenceService {
 
-    private final ArtistRepository artistRepository;
-    private final AlbumRepository albumRepository;
-    private final SongRepository songRepository;
-    private final ArtistSongRepository artistSongRepository;
-    private final ArtistAlbumRepository artistAlbumRepository;
-    private final SimilarSongRepository similarSongRepository;
     private final TransactionalOperator transactionalOperator;
+    
+    private final ArtistBatchProcessor artistBatchProcessor;
+    private final AlbumBatchProcessor albumBatchProcessor;
+    private final SongBatchProcessor songBatchProcessor;
+    private final RelationshipDataProcessor relationshipProcessor;
 
     /**
      * Map 데이터 리스트를 처리하고 저장
-     * Map → DTO → Domain 변환 후 저장
+     * Map → DTO → Domain 변환 후 Bulk 저장
+     * 배치 크기: 1000개 단위로 처리
      */
     public Mono<Void> processSongBatch(List<Map<String, Object>> songMaps) {
-        return Flux.fromIterable(songMaps)
-            .mapNotNull(SpotifyDataMapper::mapToSpotifySongDto)
-            .flatMap(this::processSingleSong)
-            .then()
-            .as(transactionalOperator::transactional)
-            .doOnError(e -> log.error("Error processing song batch", e));
-    }
+        List<SpotifySongDto> songDtos = convertToDtos(songMaps);
 
-    /**
-     * 단일 곡 데이터 처리 및 저장
-     */
-    private Mono<Void> processSingleSong(SpotifySongDto dto) {
-        List<Artist> artistsToProcess = SpotifyDomainMapper.extractArtists(dto);
-        Album albumToProcess = SpotifyDomainMapper.extractAlbum(dto);
-
-        Mono<List<Artist>> artistsMono = processArtists(artistsToProcess);
-        Mono<Album> albumMono = processAlbum(albumToProcess);
-
-        return Mono.zip(artistsMono, albumMono)
-            .flatMap(tuple -> {
-                List<Artist> artists = tuple.getT1();
-                Album album = tuple.getT2();
-
-                return processSong(dto, album.getId())
-                    .flatMap(song -> {
-                        Mono<Void> artistSongRelations = saveArtistSongRelations(artists, song);
-                        Mono<Void> artistAlbumRelations = saveArtistAlbumRelations(artists, album);
-                        Mono<Void> similarSongRelations = processSimilarSongs(dto, song);
-                        return Mono.when(artistSongRelations, artistAlbumRelations, similarSongRelations);
-                    });
-            }).then();
-    }
-
-    /**
-     * 아티스트 처리 (복수 아티스트 지원)
-     */
-    private Mono<List<Artist>> processArtists(List<Artist> artists) {
-        if (artists == null || artists.isEmpty()) {
-            return Mono.just(Collections.emptyList());
-        }
-
-        List<Mono<Artist>> artistMonos = new ArrayList<>();
-
-        for (Artist artist : artists) {
-            String artistName = artist.getName();
-
-            Mono<Artist> artistMono = artistRepository.findByName(artistName)
-                .switchIfEmpty(
-                    Mono.defer(() -> artistRepository.save(artist))
-                );
-
-            artistMonos.add(artistMono);
-        }
-
-        return Flux.merge(artistMonos).collectList();
-    }
-
-    /**
-     * 앨범 처리
-     * title + release_date로 중복 체크
-     * (하나의 앨범은 여러 아티스트가 공유할 수 있으므로 artist_id를 포함하지 않음)
-     */
-    private Mono<Album> processAlbum(Album album) {
-        String albumTitle = album.getTitle();
-
-        return albumRepository.findByTitleAndReleaseDate(albumTitle, album.getReleaseDate())
-            .switchIfEmpty(Mono.defer(() -> albumRepository.save(album)));
-    }
-
-    /**
-     * 곡 처리
-     */
-    private Mono<Song> processSong(SpotifySongDto dto, Long albumId) {
-        Song songToSave = SpotifyDomainMapper.convertToSong(dto, albumId);
-        String title = songToSave.getTitle();
-
-        return songRepository.findByTitleAndAlbumId(title, albumId)
-            .switchIfEmpty(
-                Mono.defer(() -> songRepository.save(songToSave))
-            );
-    }
-
-    /**
-     * 아티스트-곡 관계 저장
-     * artist_id와 song_id의 조합으로 중복 체크
-     * (song 자체에 album_id가 포함되어 있으므로 song_id로 충분함)
-     */
-    private Mono<Void> saveArtistSongRelations(List<Artist> artists, Song song) {
-        return Flux.fromIterable(artists)
-            .flatMap(artist ->
-                artistSongRepository.findByArtistIdAndSongId(artist.getId(), song.getId())
-                    .switchIfEmpty(
-                        Mono.defer(() -> {
-                            ArtistSong artistSong = SpotifyDomainMapper.createArtistSong(artist.getId(), song.getId());
-                            return artistSongRepository.save(artistSong);
-                        })
-                    )
-            )
-            .then();
-    }
-
-    /**
-     * 아티스트-앨범 관계 저장
-     */
-    private Mono<Void> saveArtistAlbumRelations(List<Artist> artists, Album album) {
-        return Flux.fromIterable(artists)
-            .flatMap(artist ->
-                artistAlbumRepository.findByArtistIdAndAlbumId(artist.getId(), album.getId())
-                    .switchIfEmpty(
-                        Mono.defer(() -> {
-                            ArtistAlbum artistAlbum = SpotifyDomainMapper.createArtistAlbum(artist.getId(), album.getId());
-                            return artistAlbumRepository.save(artistAlbum);
-                        })
-                    )
-            )
-            .then();
-    }
-
-    /**
-     * Similar Songs 처리 - artist name과 song title을 직접 저장
-     */
-    private Mono<Void> processSimilarSongs(SpotifySongDto dto, Song song) {
-        if (dto.getSimilarSongs() == null || dto.getSimilarSongs().isEmpty()) {
+        if (songDtos.isEmpty()) {
+            log.debug("No valid songs in batch");
             return Mono.empty();
         }
 
-        return Flux.fromIterable(dto.getSimilarSongs())
-            .flatMap(similarDto -> saveSimilarSongRelation(song.getId(), similarDto))
-            .then();
+        return processBatchInternal(songDtos)
+            .as(transactionalOperator::transactional)
+            .subscribeOn(Schedulers.boundedElastic()); // I/O 작업에 최적화된 스케줄러
     }
 
     /**
-     * Similar Song 관계 저장 - 중복 체크 후 저장
+     * Map 데이터를 DTO로 변환
      */
-    private Mono<Void> saveSimilarSongRelation(Long songId, SimilarSongDto similarDto) {
-        String artistName = similarDto.getArtistName();
-        String songTitle = similarDto.getSongTitle();
-        BigDecimal score = similarDto.getSimilarityScore();
+    private List<SpotifySongDto> convertToDtos(List<Map<String, Object>> songMaps) {
+        return songMaps.stream()
+            .map(SpotifyDataMapper::mapToSpotifySongDto)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
 
-        return similarSongRepository.findBySongIdAndSimilarInfo(songId, artistName, songTitle)
-            .switchIfEmpty(
-                Mono.defer(() -> {
-                    SimilarSong relation = SpotifyDomainMapper.createSimilarSong(
-                        songId, artistName, songTitle, score
-                    );
-                    return similarSongRepository.save(relation);
-                })
-            )
-            .then()
-            .doOnSuccess(v -> log.debug("Saved similar song relation: {} - {} (score: {})",
-                artistName, songTitle, score));
+    /**
+     * 배치 데이터 내부 처리
+     * 1. Artists & Albums 병렬 처리 (중복 체크 필요)
+     * 2. Songs & Relations 순차 처리 (Bulk Insert)
+     */
+    private Mono<Void> processBatchInternal(List<SpotifySongDto> songDtos) {
+        BatchContext context = BatchContext.from(songDtos);
+
+        return processArtistsAndAlbums(context)
+            .flatMap(tuple -> processSongsWithRelations(songDtos, tuple.getT1(), tuple.getT2()));
+    }
+
+    /**
+     * Artists와 Albums 병렬 처리
+     */
+    private Mono<Tuple2<Map<String, Artist>, Map<String, Album>>> processArtistsAndAlbums(BatchContext context) {
+        Mono<Map<String, Artist>> artistsMapMono = artistBatchProcessor.processArtistsBatch(context.artistNames());
+        Mono<Map<String, Album>> albumsMapMono = albumBatchProcessor.processAlbumsBatch(context.albumsByTitle());
+
+        return Mono.zip(artistsMapMono, albumsMapMono);
+    }
+
+
+    /**
+     * Songs와 관계 데이터 처리
+     */
+    private Mono<Void> processSongsWithRelations(List<SpotifySongDto> songDtos,
+                                                 Map<String, Artist> artistsMap,
+                                                 Map<String, Album> albumsMap) {
+        return songBatchProcessor.processSongsBatch(songDtos, albumsMap)
+            .flatMap(songResult -> {
+                if (songResult.savedSongs().isEmpty()) {
+                    return Mono.empty();
+                }
+                
+                return processRelationships(
+                    songResult.savedSongs(), 
+                    songDtos, 
+                    artistsMap, 
+                    albumsMap, 
+                    songResult.songIndexToAlbumKey()
+                );
+            });
+    }
+
+    /**
+     * 관계 데이터 처리
+     */
+    private Mono<Void> processRelationships(List<Song> savedSongs,
+                                            List<SpotifySongDto> songDtos,
+                                            Map<String, Artist> artistsMap,
+                                            Map<String, Album> albumsMap,
+                                            Map<Integer, String> songIndexToAlbumKey) {
+        RelationshipDataProcessor.RelationshipData relationships =
+            RelationshipDataProcessor.buildRelationships(
+                savedSongs, songDtos, artistsMap, albumsMap, songIndexToAlbumKey
+            );
+
+        return insertRelationships(relationships);
+    }
+
+    /**
+     * 관계 데이터 Bulk Insert
+     */
+    private Mono<Void> insertRelationships(RelationshipDataProcessor.RelationshipData relationships) {
+        List<Mono<Long>> insertOps = new ArrayList<>();
+        
+        if (!relationships.artistSongs().isEmpty()) {
+            insertOps.add(relationshipProcessor.bulkInsertArtistSongs(relationships.artistSongs()));
+        }
+
+        if (!relationships.artistAlbums().isEmpty()) {
+            insertOps.add(relationshipProcessor.bulkInsertArtistAlbums(relationships.artistAlbums()));
+        }
+
+        if (!relationships.similarSongs().isEmpty()) {
+            insertOps.add(relationshipProcessor.bulkInsertSimilarSongs(relationships.similarSongs()));
+        }
+
+        return Mono.when(insertOps);
     }
 
 }

--- a/src/main/java/com/example/spotify_song_subject/controller/AlbumStatisticsController.java
+++ b/src/main/java/com/example/spotify_song_subject/controller/AlbumStatisticsController.java
@@ -1,12 +1,12 @@
 package com.example.spotify_song_subject.controller;
 
 import com.example.spotify_song_subject.controller.response.AlbumStatisticsResponse;
+import com.example.spotify_song_subject.controller.util.PageableUtils;
 import com.example.spotify_song_subject.application.AlbumStatisticsQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -28,11 +28,14 @@ public class AlbumStatisticsController {
      */
     @GetMapping
     public Mono<ResponseEntity<Page<AlbumStatisticsResponse>>> getAlbumStatistics(@RequestParam(required = true) Integer year,
-                                                                                  @PageableDefault(size = 10) Pageable pageable) {
-        Mono<Page<AlbumStatisticsResponse>> response = albumStatisticsQueryService.getAlbumStatisticsByYear(year, pageable)
-            .map(dtoPage -> dtoPage.map(AlbumStatisticsResponse::from));
-
-        return response.map(ResponseEntity::ok)
+                                                                                  @RequestParam(required = false) Integer page,
+                                                                                  @RequestParam(required = false) Integer size) {
+        
+        Pageable pageable = PageableUtils.createPageable(page, size);
+        
+        return albumStatisticsQueryService.getAlbumStatisticsByYear(year, pageable)
+            .map(dtoPage -> dtoPage.map(AlbumStatisticsResponse::from))
+            .map(ResponseEntity::ok)
             .switchIfEmpty(Mono.just(ResponseEntity.noContent().build()));
     }
 }

--- a/src/main/java/com/example/spotify_song_subject/controller/response/AlbumStatisticsResponse.java
+++ b/src/main/java/com/example/spotify_song_subject/controller/response/AlbumStatisticsResponse.java
@@ -8,16 +8,11 @@ import java.time.LocalDate;
  * 앨범 통계 응답 DTO
  * 앨범별 통계 정보를 담는 응답 객체
  */
-public record AlbumStatisticsResponse(
-        Long albumId,
-        String albumName,
-        Long artistId,
-        String artistName,
-        LocalDate releaseDate,
-        Integer releaseYear,
-        Long albumCount,
-        Long songCount
-) {
+public record AlbumStatisticsResponse(Long artistId,
+                                      String artistName,
+                                      LocalDate releaseDate,
+                                      Integer releaseYear,
+                                      Long albumCount) {
 
     /**
      * AlbumStatisticsDto로부터 Response 객체 생성
@@ -26,14 +21,11 @@ public record AlbumStatisticsResponse(
      */
     public static AlbumStatisticsResponse from(AlbumStatisticsDto dto) {
         return new AlbumStatisticsResponse(
-                dto.getAlbumId(),
-                dto.getAlbumName(),
                 dto.getArtistId(),
                 dto.getArtistName(),
                 dto.getReleaseDate(),
                 dto.getReleaseYear(),
-                dto.getAlbumCount(),
-                dto.getSongCount()
+                dto.getAlbumCount()
         );
     }
 }

--- a/src/main/java/com/example/spotify_song_subject/controller/util/PageableUtils.java
+++ b/src/main/java/com/example/spotify_song_subject/controller/util/PageableUtils.java
@@ -1,0 +1,25 @@
+package com.example.spotify_song_subject.controller.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Pageable 관련 유틸리티 클래스
+ * WebFlux에서 Pageable 파라미터 처리를 위한 헬퍼 메서드 제공
+ */
+public class PageableUtils {
+    
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 10;
+    private static final int MAX_SIZE = 100;
+    
+    /**
+     * 요청 파라미터로부터 Pageable 객체 생성
+     */
+    public static Pageable createPageable(Integer page, Integer size) {
+        int pageNumber = page != null ? page : DEFAULT_PAGE;
+        int pageSize = size != null ? Math.min(size, MAX_SIZE) : DEFAULT_SIZE;
+
+        return PageRequest.of(pageNumber, pageSize);
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/domain/Album.java
+++ b/src/main/java/com/example/spotify_song_subject/domain/Album.java
@@ -25,10 +25,35 @@ public class Album extends BaseDomain {
     @Column("release_date")
     private LocalDate releaseDate;
 
+    @Column("artist_name")
+    private String artistName;
+
     @Builder
-    public Album(String title, LocalDate releaseDate) {
+    public Album(String title, LocalDate releaseDate, String artistName) {
         this.title = title;
         this.releaseDate = releaseDate;
+        this.artistName = artistName;
+    }
+
+    /**
+     * 정적 팩토리 메소드 - 타이틀과 발매일로 Album 생성
+     */
+    public static Album of(String title, LocalDate releaseDate) {
+        return Album.builder()
+            .title(title)
+            .releaseDate(releaseDate)
+            .build();
+    }
+    
+    /**
+     * 정적 팩토리 메소드 - 타이틀, 발매일, 아티스트명으로 Album 생성
+     */
+    public static Album of(String title, LocalDate releaseDate, String artistName) {
+        return Album.builder()
+            .title(title)
+            .releaseDate(releaseDate)
+            .artistName(artistName)
+            .build();
     }
 
 }

--- a/src/main/java/com/example/spotify_song_subject/domain/Artist.java
+++ b/src/main/java/com/example/spotify_song_subject/domain/Artist.java
@@ -24,4 +24,10 @@ public class Artist extends BaseDomain {
     public Artist(String name) {
         this.name = name;
     }
+
+    public static Artist of(String name) {
+        return Artist.builder()
+            .name(name)
+            .build();
+    }
 }

--- a/src/main/java/com/example/spotify_song_subject/dto/AlbumStatisticsDto.java
+++ b/src/main/java/com/example/spotify_song_subject/dto/AlbumStatisticsDto.java
@@ -17,13 +17,10 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class AlbumStatisticsDto {
 
-    private Long albumId;
-    private String albumName;
     private Long artistId;
     private String artistName;
     private LocalDate releaseDate;
     private Integer releaseYear;
     private Long albumCount;
-    private Long songCount;
 
 }

--- a/src/main/java/com/example/spotify_song_subject/dto/BatchContext.java
+++ b/src/main/java/com/example/spotify_song_subject/dto/BatchContext.java
@@ -1,0 +1,135 @@
+package com.example.spotify_song_subject.dto;
+
+import com.example.spotify_song_subject.application.AlbumBatchProcessor;
+import com.example.spotify_song_subject.mapper.SpotifyDomainMapper;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.*;
+
+/**
+ * 배치 처리를 위한 데이터 수집 컨텍스트
+ * 배치 내의 모든 아티스트, 앨범 정보를 집계하여 중복 제거 및 Bulk 처리 지원
+ */
+@Builder
+public record BatchContext(Set<String> artistNames,
+                           Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle,
+                           List<SpotifySongDto> songs) {
+
+    /**
+     * SpotifySongDto 리스트로부터 BatchContext 생성
+     */
+    public static BatchContext from(List<SpotifySongDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return empty();
+        }
+
+        Set<String> artistNames = extractArtistNames(dtos);
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = extractAlbumsByTitle(dtos);
+
+        return BatchContext.builder()
+            .artistNames(artistNames)
+            .albumsByTitle(albumsByTitle)
+            .songs(dtos)
+            .build();
+    }
+
+    /**
+     * 빈 BatchContext 생성
+     */
+    public static BatchContext empty() {
+        return BatchContext.builder()
+            .artistNames(new HashSet<>())
+            .albumsByTitle(new HashMap<>())
+            .songs(new ArrayList<>())
+            .build();
+    }
+
+    /**
+     * DTO 리스트에서 아티스트 이름 추출
+     */
+    private static Set<String> extractArtistNames(List<SpotifySongDto> dtos) {
+        Set<String> artistNames = new HashSet<>();
+
+        for (SpotifySongDto dto : dtos) {
+            addArtistsFromDto(dto, artistNames);
+        }
+
+        return artistNames;
+    }
+
+    /**
+     * 단일 DTO에서 아티스트 추가
+     */
+    private static void addArtistsFromDto(SpotifySongDto dto, Set<String> artistNames) {
+        if (!hasArtists(dto)) {
+            return;
+        }
+
+        String[] artists = dto.getArtists().split(",");
+        for (String artist : artists) {
+            String trimmedArtist = artist.trim();
+            if (!trimmedArtist.isEmpty()) {
+                artistNames.add(trimmedArtist);
+            }
+        }
+    }
+
+    /**
+     * DTO가 아티스트 정보를 가지고 있는지 확인
+     */
+    private static boolean hasArtists(SpotifySongDto dto) {
+        return dto != null && dto.getArtists() != null && !dto.getArtists().isEmpty();
+    }
+
+    /**
+     * DTO 리스트에서 앨범 정보 추출
+     */
+    private static Map<String, Set<AlbumBatchProcessor.AlbumInfo>> extractAlbumsByTitle(List<SpotifySongDto> dtos) {
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = new HashMap<>();
+
+        for (SpotifySongDto dto : dtos) {
+            addAlbumFromDto(dto, albumsByTitle);
+        }
+
+        return albumsByTitle;
+    }
+
+    /**
+     * 단일 DTO에서 앨범 정보 추가
+     */
+    private static void addAlbumFromDto(SpotifySongDto dto, Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle) {
+        if (!hasAlbumTitle(dto)) {
+            return;
+        }
+
+        LocalDate releaseDate = SpotifyDomainMapper.parseReleaseDate(dto.getReleaseDate());
+        String artistName = extractAllArtists(dto);
+        
+        AlbumBatchProcessor.AlbumInfo albumInfo = new AlbumBatchProcessor.AlbumInfo(releaseDate, artistName);
+        albumsByTitle.computeIfAbsent(dto.getAlbumTitle(), k -> new HashSet<>())
+                    .add(albumInfo);
+    }
+    
+    /**
+     * DTO에서 전체 아티스트 이름 추출 (앨범용)
+     * 앨범에는 모든 아티스트가 포함되어야 함 (예: "A, B, C")
+     */
+    private static String extractAllArtists(SpotifySongDto dto) {
+        if (!hasArtists(dto)) {
+            return "Unknown Artist";
+        }
+        
+        return dto.getArtists().trim();
+    }
+
+    /**
+     * DTO가 앨범 타이틀을 가지고 있는지 확인
+     */
+    private static boolean hasAlbumTitle(SpotifySongDto dto) {
+        return dto != null &&
+               dto.getAlbumTitle() != null &&
+               !dto.getAlbumTitle().trim().isEmpty();
+    }
+
+}

--- a/src/main/java/com/example/spotify_song_subject/mapper/SpotifyDomainMapper.java
+++ b/src/main/java/com/example/spotify_song_subject/mapper/SpotifyDomainMapper.java
@@ -44,7 +44,7 @@ public class SpotifyDomainMapper {
     }
 
     /**
-     * SpotifySongDto에서 Album 엔티티 추출
+     * SpotifySongDto에서 Album 엔티티 추출 (첫 번째 아티스트를 대표 아티스트로 사용)
      */
     public static Album extractAlbum(SpotifySongDto dto) {
         String albumTitle = dto.getAlbumTitle();
@@ -53,7 +53,21 @@ public class SpotifyDomainMapper {
         }
 
         LocalDate releaseDate = parseReleaseDate(dto.getReleaseDate());
-        return createAlbum(albumTitle, releaseDate);
+        String artistName = extractAllArtistNames(dto);
+        return createAlbum(albumTitle, releaseDate, artistName);
+    }
+    
+    /**
+     * DTO에서 전체 아티스트명 추출 (앨범용)
+     * 앨범에는 모든 아티스트가 포함되어야 함 (예: "A, B, C")
+     */
+    private static String extractAllArtistNames(SpotifySongDto dto) {
+        if (dto.getArtists() == null || dto.getArtists().isEmpty()) {
+            return "Unknown Artist";
+        }
+        
+        // 앨범에는 전체 아티스트 이름을 저장
+        return dto.getArtists().trim();
     }
 
     /**
@@ -130,24 +144,26 @@ public class SpotifyDomainMapper {
                 .name(name)
                 .build();
     }
-
-    private static Album createAlbum(String title, LocalDate releaseDate) {
+    
+    private static Album createAlbum(String title, LocalDate releaseDate, String artistName) {
         return Album.builder()
                 .title(title)
                 .releaseDate(releaseDate)
+                .artistName(artistName)
                 .build();
     }
 
     private static Album createDefaultAlbum() {
         return Album.builder()
                 .title("Unknown Album")
+                .artistName("Unknown Artist")
                 .build();
     }
 
     /**
      * 날짜 파싱
      */
-    private static LocalDate parseReleaseDate(String dateStr) {
+    public static LocalDate parseReleaseDate(String dateStr) {
         if (dateStr == null || dateStr.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/example/spotify_song_subject/repository/AlbumRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/AlbumRepository.java
@@ -4,14 +4,23 @@ import com.example.spotify_song_subject.domain.Album;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
+import java.util.Collection;
 
 @Repository
 public interface AlbumRepository extends R2dbcRepository<Album, Long> {
 
     @Query("SELECT * FROM albums WHERE title = :title AND release_date = :releaseDate AND deleted_at IS NULL")
     Mono<Album> findByTitleAndReleaseDate(String title, LocalDate releaseDate);
+    
+    /**
+     * 여러 앨범을 title로 한번에 조회
+     * title IN 절을 사용하여 성능 최적화
+     */
+    @Query("SELECT * FROM albums WHERE title IN (:titles) AND deleted_at IS NULL")
+    Flux<Album> findAllByTitleIn(Collection<String> titles);
 
 }

--- a/src/main/java/com/example/spotify_song_subject/repository/ArtistRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/ArtistRepository.java
@@ -4,12 +4,23 @@ import com.example.spotify_song_subject.domain.Artist;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Collection;
 
 @Repository
 public interface ArtistRepository extends R2dbcRepository<Artist, Long> {
 
     @Query("SELECT * FROM artists WHERE name = :name AND deleted_at IS NULL")
     Mono<Artist> findByName(String name);
+
+    /**
+     * Bulk 조회 - 여러 아티스트를 이름으로 한번에 조회
+     * @param names 아티스트 이름 컬렉션
+     * @return 매칭되는 아티스트 Flux
+     */
+    @Query("SELECT * FROM artists WHERE name IN (:names) AND deleted_at IS NULL")
+    Flux<Artist> findAllByNameIn(Collection<String> names);
 
 }

--- a/src/main/java/com/example/spotify_song_subject/repository/SongRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/SongRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
+import java.util.Collection;
 
 @Repository
 public interface SongRepository extends R2dbcRepository<Song, Long> {
@@ -25,7 +25,10 @@ public interface SongRepository extends R2dbcRepository<Song, Long> {
     @Query("UPDATE songs SET like_count = CASE WHEN like_count > 0 THEN like_count - 1 ELSE 0 END WHERE id = :songId")
     Mono<Integer> decrementLikeCount(Long songId);
 
-    @Query("SELECT * FROM songs WHERE id IN (:ids) AND deleted_at IS NULL")
-    Flux<Song> findByIds(@Param("ids") List<Long> ids);
+    /**
+     * title로 여러 Song을 조회 (album_id가 null인 것도 포함)
+     */
+    @Query("SELECT * FROM songs WHERE title IN (:titles) AND deleted_at IS NULL")
+    Flux<Song> findAllByTitleIn(@Param("titles") Collection<String> titles);
 
 }

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/AlbumBulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/AlbumBulkRepository.java
@@ -1,0 +1,75 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.Album;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Bulk insert repository for Albums using true bulk SQL
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AlbumBulkRepository implements BulkRepository<Album> {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Mono<Long> bulkInsert(Collection<Album> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        String sql = buildSql(entities);
+        DatabaseClient.GenericExecuteSpec spec = bindParameters(databaseClient.sql(sql), entities);
+
+        return executeInsert(spec);
+    }
+
+    private String buildSql(Collection<Album> entities) {
+        return "INSERT INTO albums (title, release_date, artist_name) VALUES " +
+                IntStream.range(0, entities.size())
+                        .mapToObj(idx -> "(:title" + idx + ", :release_date" + idx + ", :artist_name" + idx + ")")
+                        .collect(Collectors.joining(", "));
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                             Collection<Album> entities) {
+        int index = 0;
+        for (Album album : entities) {
+            spec = bindAlbumParameters(spec, album, index);
+            index++;
+        }
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindAlbumParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                                  Album album, int index) {
+        spec = spec.bind("title" + index, album.getTitle());
+
+        if (album.getReleaseDate() != null) {
+            spec = spec.bind("release_date" + index, album.getReleaseDate());
+        } else {
+            spec = spec.bindNull("release_date" + index, java.time.LocalDate.class);
+        }
+        
+        if (album.getArtistName() != null) {
+            return spec.bind("artist_name" + index, album.getArtistName());
+        }
+        return spec.bindNull("artist_name" + index, String.class);
+    }
+
+    private Mono<Long> executeInsert(DatabaseClient.GenericExecuteSpec spec) {
+        return spec.fetch()
+                .rowsUpdated()
+                .doOnSuccess(count -> log.debug("Bulk inserted {} albums", count))
+                .doOnError(error -> log.error("Failed to bulk insert albums", error));
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/ArtistAlbumBulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/ArtistAlbumBulkRepository.java
@@ -1,0 +1,66 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.ArtistAlbum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Bulk insert repository for ArtistAlbums using true bulk SQL
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ArtistAlbumBulkRepository implements BulkRepository<ArtistAlbum> {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Mono<Long> bulkInsert(Collection<ArtistAlbum> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        String sql = buildSql(entities);
+        DatabaseClient.GenericExecuteSpec spec = bindParameters(databaseClient.sql(sql), entities);
+
+        return executeInsert(spec);
+    }
+
+    private String buildSql(Collection<ArtistAlbum> entities) {
+        return "INSERT INTO artist_albums (artist_id, album_id) VALUES " +
+                IntStream.range(0, entities.size())
+                        .mapToObj(idx -> String.format("(:artist_id%d, :album_id%d)", idx, idx))
+                        .collect(Collectors.joining(", "));
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                             Collection<ArtistAlbum> entities) {
+        int index = 0;
+        for (ArtistAlbum artistAlbum : entities) {
+            spec = bindArtistAlbumParameters(spec, artistAlbum, index);
+            index++;
+        }
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindArtistAlbumParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                                        ArtistAlbum artistAlbum, int index) {
+        return spec
+                .bind("artist_id" + index, artistAlbum.getArtistId())
+                .bind("album_id" + index, artistAlbum.getAlbumId());
+    }
+
+    private Mono<Long> executeInsert(DatabaseClient.GenericExecuteSpec spec) {
+        return spec.fetch()
+                .rowsUpdated()
+                .doOnSuccess(count -> log.debug("Bulk inserted {} artist-album relationships", count))
+                .doOnError(error -> log.error("Failed to bulk insert artist-album relationships", error));
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/ArtistBulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/ArtistBulkRepository.java
@@ -1,0 +1,59 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.Artist;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Bulk insert repository for Artists using true bulk SQL
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ArtistBulkRepository implements BulkRepository<Artist> {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Mono<Long> bulkInsert(Collection<Artist> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        String sql = buildSql(entities);
+        DatabaseClient.GenericExecuteSpec spec = bindParameters(databaseClient.sql(sql), entities);
+
+        return executeInsert(spec);
+    }
+
+    private String buildSql(Collection<Artist> entities) {
+        return "INSERT IGNORE INTO artists (name) VALUES " +
+                IntStream.range(0, entities.size())
+                        .mapToObj(idx -> "(:name" + idx + ")")
+                        .collect(Collectors.joining(", "));
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                             Collection<Artist> entities) {
+        int index = 0;
+        for (Artist artist : entities) {
+            spec = spec.bind("name" + index, artist.getName());
+            index++;
+        }
+        return spec;
+    }
+
+    private Mono<Long> executeInsert(DatabaseClient.GenericExecuteSpec spec) {
+        return spec.fetch()
+                .rowsUpdated()
+                .doOnSuccess(count -> log.debug("Bulk inserted {} artists", count))
+                .doOnError(error -> log.error("Failed to bulk insert artists", error));
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/ArtistSongBulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/ArtistSongBulkRepository.java
@@ -1,0 +1,71 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.ArtistSong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Bulk insert repository for ArtistSongs using true bulk SQL
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ArtistSongBulkRepository implements BulkRepository<ArtistSong> {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Mono<Long> bulkInsert(Collection<ArtistSong> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        String sql = buildSql(entities);
+        DatabaseClient.GenericExecuteSpec spec = bindParameters(databaseClient.sql(sql), entities);
+
+        return executeInsert(spec);
+    }
+
+    private String buildSql(Collection<ArtistSong> entities) {
+        return "INSERT INTO artist_songs (artist_id, song_id) VALUES " +
+                IntStream.range(0, entities.size())
+                        .mapToObj(idx -> String.format("(:artist_id%d, :song_id%d)", idx, idx))
+                        .collect(Collectors.joining(", "));
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                             Collection<ArtistSong> entities) {
+        int index = 0;
+        for (ArtistSong artistSong : entities) {
+            spec = bindArtistSongParameters(spec, artistSong, index);
+            index++;
+        }
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindArtistSongParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                                       ArtistSong artistSong, int index) {
+        spec = spec.bind("artist_id" + index, artistSong.getArtistId());
+        
+        if (artistSong.getSongId() != null) {
+            return spec.bind("song_id" + index, artistSong.getSongId());
+        } else {
+            log.error("ArtistSong has null songId for artistId: {}", artistSong.getArtistId());
+            throw new IllegalArgumentException("ArtistSong cannot have null songId");
+        }
+    }
+
+    private Mono<Long> executeInsert(DatabaseClient.GenericExecuteSpec spec) {
+        return spec.fetch()
+                .rowsUpdated()
+                .doOnSuccess(count -> log.debug("Bulk inserted {} artist-song relationships", count))
+                .doOnError(error -> log.error("Failed to bulk insert artist-song relationships", error));
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/BulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/BulkRepository.java
@@ -1,0 +1,18 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import reactor.core.publisher.Mono;
+import java.util.Collection;
+
+/**
+ * Base interface for bulk insert operations
+ * @param <T> Entity type
+ */
+public interface BulkRepository<T> {
+
+    /**
+     * Performs true bulk insert using single SQL statement
+     * @param entities Entities to insert
+     * @return Number of inserted rows
+     */
+    Mono<Long> bulkInsert(Collection<T> entities);
+}

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/SimilarSongBulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/SimilarSongBulkRepository.java
@@ -1,0 +1,73 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.SimilarSong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Bulk insert repository for SimilarSongs using true bulk SQL
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SimilarSongBulkRepository implements BulkRepository<SimilarSong> {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Mono<Long> bulkInsert(Collection<SimilarSong> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        String sql = buildSql(entities);
+        DatabaseClient.GenericExecuteSpec spec = bindParameters(databaseClient.sql(sql), entities);
+
+        return executeInsert(spec);
+    }
+
+    private String buildSql(Collection<SimilarSong> entities) {
+        return "INSERT INTO similar_songs (song_id, similar_artist_name, similar_song_title, similarity_score) VALUES " +
+                IntStream.range(0, entities.size())
+                        .mapToObj(idx -> String.format("(:song_id%d, :similar_artist_name%d, :similar_song_title%d, :similarity_score%d)",
+                                idx, idx, idx, idx))
+                        .collect(Collectors.joining(", "));
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                             Collection<SimilarSong> entities) {
+        int index = 0;
+        for (SimilarSong similarSong : entities) {
+            spec = bindSimilarSongParameters(spec, similarSong, index);
+            index++;
+        }
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindSimilarSongParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                                        SimilarSong similarSong, int index) {
+        spec = spec
+                .bind("song_id" + index, similarSong.getSongId())
+                .bind("similar_artist_name" + index, similarSong.getSimilarArtistName())
+                .bind("similar_song_title" + index, similarSong.getSimilarSongTitle());
+
+        if (similarSong.getSimilarityScore() != null) {
+            return spec.bind("similarity_score" + index, similarSong.getSimilarityScore());
+        }
+        return spec.bindNull("similarity_score" + index, java.math.BigDecimal.class);
+    }
+
+    private Mono<Long> executeInsert(DatabaseClient.GenericExecuteSpec spec) {
+        return spec.fetch()
+                .rowsUpdated()
+                .doOnSuccess(count -> log.debug("Bulk inserted {} similar song relationships", count))
+                .doOnError(error -> log.error("Failed to bulk insert similar song relationships", error));
+    }
+}

--- a/src/main/java/com/example/spotify_song_subject/repository/bulk/SongBulkRepository.java
+++ b/src/main/java/com/example/spotify_song_subject/repository/bulk/SongBulkRepository.java
@@ -1,0 +1,160 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.Song;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Bulk insert repository for Songs using true bulk SQL
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SongBulkRepository implements BulkRepository<Song> {
+
+    private final DatabaseClient databaseClient;
+
+    @Override
+    public Mono<Long> bulkInsert(Collection<Song> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        String sql = buildSql(entities);
+        DatabaseClient.GenericExecuteSpec spec = bindParameters(databaseClient.sql(sql), entities);
+        return spec
+            .fetch()
+            .rowsUpdated();
+    }
+
+    private String buildSql(Collection<Song> entities) {
+        String columns = "INSERT INTO songs (album_id, title, lyrics, length, music_key, tempo, " +
+                "loudness_db, time_signature, explicit_content, emotion, genre, popularity, " +
+                "energy, danceability, positiveness, speechiness, liveness, acousticness, " +
+                "instrumentalness, activity_suitability_party, activity_suitability_work, " +
+                "activity_suitability_relaxation, activity_suitability_exercise, " +
+                "activity_suitability_running, activity_suitability_yoga, " +
+                "activity_suitability_driving, activity_suitability_social, " +
+                "activity_suitability_morning, like_count) VALUES ";
+
+        String values = IntStream.range(0, entities.size())
+                .mapToObj(this::buildValuePlaceholders)
+                .collect(Collectors.joining(", "));
+
+        return columns + values;
+    }
+
+    private String buildValuePlaceholders(int idx) {
+        return String.format("(:album_id%d, :title%d, :lyrics%d, :length%d, :music_key%d, " +
+                ":tempo%d, :loudness_db%d, :time_signature%d, :explicit_content%d, " +
+                ":emotion%d, :genre%d, :popularity%d, :energy%d, :danceability%d, " +
+                ":positiveness%d, :speechiness%d, :liveness%d, :acousticness%d, " +
+                ":instrumentalness%d, :activity_suitability_party%d, " +
+                ":activity_suitability_work%d, :activity_suitability_relaxation%d, " +
+                ":activity_suitability_exercise%d, :activity_suitability_running%d, " +
+                ":activity_suitability_yoga%d, :activity_suitability_driving%d, " +
+                ":activity_suitability_social%d, :activity_suitability_morning%d, " +
+                ":like_count%d)",
+                idx, idx, idx, idx, idx, idx, idx, idx, idx, idx, idx, idx, idx,
+                idx, idx, idx, idx, idx, idx, idx, idx, idx, idx, idx, idx, idx,
+                idx, idx, idx);
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                             Collection<Song> entities) {
+        int index = 0;
+        for (Song song : entities) {
+            spec = bindSongParameters(spec, song, index);
+            index++;
+        }
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindSongParameters(DatabaseClient.GenericExecuteSpec spec,
+                                                                 Song song,
+                                                                 int index) {
+        // album_id에 대한 null 처리
+        if (song.getAlbumId() != null) {
+            spec = spec.bind("album_id" + index, song.getAlbumId());
+        } else {
+            spec = spec.bindNull("album_id" + index, Long.class);
+        }
+        
+        spec = spec.bind("title" + index, song.getTitle());
+        spec = bindBasicFields(spec, song, index);
+        spec = bindAudioFeatures(spec, song, index);
+        spec = bindActivitySuitabilities(spec, song, index);
+        spec = spec.bind("like_count" + index, song.getLikeCount() != null ? song.getLikeCount() : 0L);
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindBasicFields(DatabaseClient.GenericExecuteSpec spec,
+                                                              Song song,
+                                                              int index) {
+        spec = bindNullableField(spec, "lyrics" + index, song.getLyrics());
+        spec = bindNullableField(spec, "length" + index, song.getLength());
+        spec = bindNullableField(spec, "music_key" + index, song.getMusicKey());
+        spec = bindNullableField(spec, "tempo" + index, song.getTempo());
+        spec = bindNullableField(spec, "loudness_db" + index, song.getLoudnessDb());
+        spec = bindNullableField(spec, "time_signature" + index, song.getTimeSignature());
+        spec = bindNullableField(spec, "explicit_content" + index,
+                song.getExplicitContent() != null ? song.getExplicitContent().name() : null);
+        spec = bindNullableField(spec, "emotion" + index, song.getEmotion());
+        spec = bindNullableField(spec, "genre" + index, song.getGenre());
+        spec = bindNullableField(spec, "popularity" + index, song.getPopularity());
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindAudioFeatures(DatabaseClient.GenericExecuteSpec spec,
+                                                                Song song,
+                                                                int index) {
+        spec = bindNullableField(spec, "energy" + index, song.getEnergy());
+        spec = bindNullableField(spec, "danceability" + index, song.getDanceability());
+        spec = bindNullableField(spec, "positiveness" + index, song.getPositiveness());
+        spec = bindNullableField(spec, "speechiness" + index, song.getSpeechiness());
+        spec = bindNullableField(spec, "liveness" + index, song.getLiveness());
+        spec = bindNullableField(spec, "acousticness" + index, song.getAcousticness());
+        spec = bindNullableField(spec, "instrumentalness" + index, song.getInstrumentalness());
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindActivitySuitabilities(DatabaseClient.GenericExecuteSpec spec,
+                                                                        Song song,
+                                                                        int index) {
+        spec = bindNullableField(spec, "activity_suitability_party" + index,
+                song.getActivitySuitabilityParty() != null ? song.getActivitySuitabilityParty().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_work" + index,
+                song.getActivitySuitabilityWork() != null ? song.getActivitySuitabilityWork().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_relaxation" + index,
+                song.getActivitySuitabilityRelaxation() != null ? song.getActivitySuitabilityRelaxation().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_exercise" + index,
+                song.getActivitySuitabilityExercise() != null ? song.getActivitySuitabilityExercise().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_running" + index,
+                song.getActivitySuitabilityRunning() != null ? song.getActivitySuitabilityRunning().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_yoga" + index,
+                song.getActivitySuitabilityYoga() != null ? song.getActivitySuitabilityYoga().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_driving" + index,
+                song.getActivitySuitabilityDriving() != null ? song.getActivitySuitabilityDriving().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_social" + index,
+                song.getActivitySuitabilitySocial() != null ? song.getActivitySuitabilitySocial().name() : null);
+        spec = bindNullableField(spec, "activity_suitability_morning" + index,
+                song.getActivitySuitabilityMorning() != null ? song.getActivitySuitabilityMorning().name() : null);
+        return spec;
+    }
+
+    private DatabaseClient.GenericExecuteSpec bindNullableField(DatabaseClient.GenericExecuteSpec spec,
+                                                                String paramName, Object value) {
+        if (value != null) {
+            return spec.bind(paramName, value);
+        }
+
+        return spec.bindNull(paramName, String.class);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,10 +8,12 @@ spring:
     username: sa
     password:
     pool:
-      initial-size: 10
-      max-size: 30
+      initial-size: 20
+      max-size: 50
       max-idle-time: 30m
-      max-acquire-time: 2s
+      max-acquire-time: 5s
+      max-create-connection-time: 5s
+      validation-query: SELECT 1
 
   # Disable SQL initialization (handled by R2dbcConfig)
   sql:
@@ -51,9 +53,11 @@ data:
   initialization:
     enabled: true  # 데이터 초기화 활성화 (테스트 환경에서는 false로 설정)
   batch:
-    size: 1000
+    size: 100
   buffer:
-    size: 65536
+    size: 131072  # 128KB 버퍼
+  parallel:
+    batches: 5
 
 # Google Drive Configuration
 google:
@@ -64,10 +68,13 @@ google:
 # Logging
 logging:
   level:
+    com:
+      example:
+        spotify_song_subject: INFO
     org:
       springframework:
         data:
-          r2dbc: DEBUG
+          r2dbc: INFO
     io:
       r2dbc:
-        h2: DEBUG
+        h2: INFO

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS artists (
     updated_by VARCHAR(100) COMMENT '수정자'
 );
 
-CREATE INDEX IF NOT EXISTS idx_artist_name ON artists(name);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_artist_name ON artists(name);
 CREATE INDEX IF NOT EXISTS idx_artist_deleted_at ON artists(deleted_at);
 
 -- 2. Albums 테이블: 앨범 정보를 저장하는 테이블
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS albums (
     id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '앨범 고유 ID',
     title VARCHAR(255) NOT NULL COMMENT '앨범 제목',
     release_date DATE COMMENT '발매일',
+    artist_name VARCHAR(1000) COMMENT '대표 아티스트명',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일시',
     deleted_at TIMESTAMP NULL COMMENT '삭제일시 (논리 삭제용)',
@@ -25,8 +26,10 @@ CREATE TABLE IF NOT EXISTS albums (
 );
 
 CREATE INDEX IF NOT EXISTS idx_album_release_date ON albums(release_date);
-CREATE INDEX IF NOT EXISTS idx_album_title_date ON albums(title, release_date); -- 중복 체크용 복합 인덱스
+CREATE INDEX IF NOT EXISTS idx_album_title_date_artist ON albums(title, release_date, artist_name);
 CREATE INDEX IF NOT EXISTS idx_album_deleted_at ON albums(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_album_release_date_deleted ON albums(release_date, deleted_at);
+CREATE INDEX IF NOT EXISTS idx_album_title ON albums(title);
 
 -- 3. Artist_Albums 테이블: 아티스트와 앨범의 관계를 저장하는 테이블
 CREATE TABLE IF NOT EXISTS artist_albums (
@@ -43,6 +46,7 @@ CREATE TABLE IF NOT EXISTS artist_albums (
 CREATE INDEX IF NOT EXISTS idx_artist_albums_album_artist ON artist_albums(album_id, artist_id);
 CREATE INDEX IF NOT EXISTS idx_artist_albums_artist ON artist_albums(artist_id); -- 아티스트별 앨범 조회용
 CREATE INDEX IF NOT EXISTS idx_artist_albums_deleted_at ON artist_albums(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_artist_albums_deleted_album ON artist_albums(deleted_at, album_id, artist_id); -- deleted_at 필터링 최적화
 
 -- 4. Songs 테이블: 곡 정보를 저장하는 테이블
 CREATE TABLE IF NOT EXISTS songs (
@@ -84,7 +88,8 @@ CREATE TABLE IF NOT EXISTS songs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_song_album ON songs(album_id);
-CREATE INDEX IF NOT EXISTS idx_song_title_album ON songs(title, album_id); -- 중복 체크용 복합 인덱스
+CREATE INDEX IF NOT EXISTS idx_song_title_album ON songs(title, album_id);
+CREATE INDEX IF NOT EXISTS idx_song_title ON songs(title);
 CREATE INDEX IF NOT EXISTS idx_song_genre ON songs(genre);
 CREATE INDEX IF NOT EXISTS idx_song_like_count ON songs(like_count DESC);
 CREATE INDEX IF NOT EXISTS idx_song_deleted_at ON songs(deleted_at);

--- a/src/test/java/com/example/spotify_song_subject/application/AlbumBatchProcessorTest.java
+++ b/src/test/java/com/example/spotify_song_subject/application/AlbumBatchProcessorTest.java
@@ -1,0 +1,235 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.Album;
+import com.example.spotify_song_subject.repository.AlbumRepository;
+import com.example.spotify_song_subject.repository.bulk.AlbumBulkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("AlbumBatchProcessor 단위 테스트")
+class AlbumBatchProcessorTest {
+
+    private AlbumRepository albumRepository;
+    private AlbumBulkRepository albumBulkRepository;
+
+    private AlbumBatchProcessor albumBatchProcessor;
+
+    @BeforeEach
+    void setUp() {
+        this.albumRepository = mock(AlbumRepository.class);
+        this.albumBulkRepository = mock(AlbumBulkRepository.class);
+        this.albumBatchProcessor = new AlbumBatchProcessor(albumRepository, albumBulkRepository);
+    }
+
+    @Test
+    @DisplayName("빈 앨범 맵으로 빈 결과를 반환한다")
+    void processEmptyAlbumMap() {
+        // given
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> emptyMap = Collections.emptyMap();
+
+        // when & then
+        StepVerifier.create(albumBatchProcessor.processAlbumsBatch(emptyMap))
+            .expectNext(Collections.emptyMap())
+            .verifyComplete();
+
+        // verify no repository calls
+        verifyNoInteractions(albumRepository, albumBulkRepository);
+    }
+
+    @Test
+    @DisplayName("새로운 앨범들을 일괄 삽입한다")
+    void processNewAlbums() {
+        // given
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = new HashMap<>();
+        albumsByTitle.put("Album 1", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 1, 1), "Artist1")));
+        albumsByTitle.put("Album 2", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 2, 1), "Artist2")));
+
+        Album album1 = createAlbumWithId(1L, "Album 1", LocalDate.of(2023, 1, 1), "Artist1");
+        Album album2 = createAlbumWithId(2L, "Album 2", LocalDate.of(2023, 2, 1), "Artist2");
+
+        // Mock: IN 절로 조회 시 빈 결과 반환 (기존 앨범 없음)
+        when(albumRepository.findAllByTitleIn(anyCollection()))
+            .thenReturn(Flux.empty())  // 첫 번째 조회: 기존 앨범 없음
+            .thenReturn(Flux.just(album1, album2));  // 두 번째 조회: 삽입 후
+
+        // Mock bulk insert
+        when(albumBulkRepository.bulkInsert(anyCollection()))
+            .thenReturn(Mono.just(2L));
+
+        // when
+        StepVerifier.create(albumBatchProcessor.processAlbumsBatch(albumsByTitle))
+            .assertNext(resultMap -> {
+                assertThat(resultMap).hasSize(2);
+                assertThat(resultMap).containsKey("Album 1|2023-01-01|Artist1");
+                assertThat(resultMap).containsKey("Album 2|2023-02-01|Artist2");
+                assertThat(resultMap.get("Album 1|2023-01-01|Artist1").getTitle()).isEqualTo("Album 1");
+                assertThat(resultMap.get("Album 2|2023-02-01|Artist2").getTitle()).isEqualTo("Album 2");
+            })
+            .verifyComplete();
+
+        // verify bulk insert was called
+        verify(albumBulkRepository, times(1)).bulkInsert(anyCollection());
+    }
+
+    @Test
+    @DisplayName("기존 앨범은 건너뛰고 새 앨범만 삽입한다")
+    void processWithExistingAlbums() {
+        // given
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = new HashMap<>();
+        albumsByTitle.put("Existing Album", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 1, 1), "Artist1")));
+        albumsByTitle.put("New Album", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 2, 1), "Artist2")));
+
+        Album existingAlbum = createAlbumWithId(1L, "Existing Album", LocalDate.of(2023, 1, 1), "Artist1");
+        Album newAlbum = createAlbumWithId(2L, "New Album", LocalDate.of(2023, 2, 1), "Artist2");
+
+        // Mock: IN 절 조회 - 첫 번째는 기존 앨범만, 두 번째는 모든 앨범
+        when(albumRepository.findAllByTitleIn(anyCollection()))
+            .thenReturn(Flux.just(existingAlbum))  // 첫 번째 조회: 기존 앨범만
+            .thenReturn(Flux.just(existingAlbum, newAlbum));  // 두 번째 조회: 모든 앨범
+
+        // Mock bulk insert for new album only
+        when(albumBulkRepository.bulkInsert(anyCollection()))
+            .thenReturn(Mono.just(1L));
+
+        // when
+        StepVerifier.create(albumBatchProcessor.processAlbumsBatch(albumsByTitle))
+            .assertNext(resultMap -> {
+                assertThat(resultMap).hasSize(2);
+                assertThat(resultMap).containsKey("Existing Album|2023-01-01|Artist1");
+                assertThat(resultMap).containsKey("New Album|2023-02-01|Artist2");
+            })
+            .verifyComplete();
+
+        // verify bulk insert was called once for the new album
+        verify(albumBulkRepository, times(1)).bulkInsert(argThat(collection -> collection.size() == 1));
+    }
+
+    @Test
+    @DisplayName("모든 앨범이 이미 존재하면 bulk insert를 호출하지 않는다")
+    void processAllExistingAlbums() {
+        // given
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = new HashMap<>();
+        albumsByTitle.put("Album 1", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 1, 1), "Artist1")));
+        albumsByTitle.put("Album 2", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 2, 1), "Artist2")));
+
+        Album album1 = createAlbumWithId(1L, "Album 1", LocalDate.of(2023, 1, 1), "Artist1");
+        Album album2 = createAlbumWithId(2L, "Album 2", LocalDate.of(2023, 2, 1), "Artist2");
+
+        // Mock: IN 절 조회 - 모든 앨범이 이미 존재
+        when(albumRepository.findAllByTitleIn(anyCollection()))
+            .thenReturn(Flux.just(album1, album2));
+
+        // when
+        StepVerifier.create(albumBatchProcessor.processAlbumsBatch(albumsByTitle))
+            .assertNext(resultMap -> {
+                assertThat(resultMap).hasSize(2);
+                assertThat(resultMap.get("Album 1|2023-01-01|Artist1")).isEqualTo(album1);
+                assertThat(resultMap.get("Album 2|2023-02-01|Artist2")).isEqualTo(album2);
+            })
+            .verifyComplete();
+
+        // verify bulk insert was never called
+        verify(albumBulkRepository, never()).bulkInsert(anyCollection());
+    }
+
+    @Test
+    @DisplayName("동일한 제목에 다른 발매일을 가진 앨범들을 처리한다")
+    void processAlbumsWithSameTitleDifferentDates() {
+        // given
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = new HashMap<>();
+        Set<AlbumBatchProcessor.AlbumInfo> albumInfos = new HashSet<>();
+        albumInfos.add(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 1, 1), "Artist1"));
+        albumInfos.add(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 6, 1), "Artist2"));
+        albumInfos.add(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 12, 1), "Artist3"));
+        albumsByTitle.put("Album", albumInfos);
+
+        Album album1 = createAlbumWithId(1L, "Album", LocalDate.of(2023, 1, 1), "Artist1");
+        Album album2 = createAlbumWithId(2L, "Album", LocalDate.of(2023, 6, 1), "Artist2");
+        Album album3 = createAlbumWithId(3L, "Album", LocalDate.of(2023, 12, 1), "Artist3");
+
+        // Mock: IN 절 조회 - 모든 앨범이 새로운 것
+        when(albumRepository.findAllByTitleIn(anyCollection()))
+            .thenReturn(Flux.empty())  // 첫 번째 조회: 비어있음
+            .thenReturn(Flux.just(album1, album2, album3));  // 두 번째 조회: 삽입 후
+
+        // Mock bulk insert
+        when(albumBulkRepository.bulkInsert(anyCollection()))
+            .thenReturn(Mono.just(3L));
+
+        // when
+        StepVerifier.create(albumBatchProcessor.processAlbumsBatch(albumsByTitle))
+            .assertNext(resultMap -> {
+                assertThat(resultMap).hasSize(3);
+                assertThat(resultMap).containsKey("Album|2023-01-01|Artist1");
+                assertThat(resultMap).containsKey("Album|2023-06-01|Artist2");
+                assertThat(resultMap).containsKey("Album|2023-12-01|Artist3");
+            })
+            .verifyComplete();
+
+        // verify bulk insert was called with 3 albums
+        verify(albumBulkRepository, times(1)).bulkInsert(argThat(collection -> collection.size() == 3));
+    }
+
+    @Test
+    @DisplayName("대량 데이터를 처리한다")
+    void processLargeDataSet() {
+        // given
+        Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albumsByTitle = new HashMap<>();
+        List<Album> expectedAlbums = new ArrayList<>();
+        
+        for (int i = 0; i < 100; i++) {
+            String title = "Album " + i;
+            LocalDate date = LocalDate.of(2023, 1, 1).plusDays(i);
+            String artistName = "Artist " + i;
+            albumsByTitle.put(title, Set.of(new AlbumBatchProcessor.AlbumInfo(date, artistName)));
+            expectedAlbums.add(createAlbumWithId((long)(i + 1), title, date, artistName));
+        }
+
+        // Mock: IN 절 조회 - 모든 앨범이 새로운 것
+        when(albumRepository.findAllByTitleIn(anyCollection()))
+            .thenReturn(Flux.empty())  // 첫 번째 조회: 비어있음
+            .thenReturn(Flux.fromIterable(expectedAlbums));  // 두 번째 조회: 삽입 후
+
+        // Mock bulk insert
+        when(albumBulkRepository.bulkInsert(anyCollection()))
+            .thenReturn(Mono.just(100L));
+
+        // when
+        StepVerifier.create(albumBatchProcessor.processAlbumsBatch(albumsByTitle))
+            .assertNext(resultMap -> {
+                assertThat(resultMap).hasSize(100);
+            })
+            .verifyComplete();
+
+        // verify bulk insert was called once
+        verify(albumBulkRepository, times(1)).bulkInsert(argThat(collection -> collection.size() == 100));
+    }
+
+    private Album createAlbumWithId(Long id, String title, LocalDate releaseDate) {
+        return createAlbumWithId(id, title, releaseDate, "Unknown Artist");
+    }
+    
+    private Album createAlbumWithId(Long id, String title, LocalDate releaseDate, String artistName) {
+        Album album = Album.of(title, releaseDate, artistName);
+
+        try {
+            java.lang.reflect.Field idField = album.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(album, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return album;
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/application/AlbumStatisticsQueryServiceTest.java
+++ b/src/test/java/com/example/spotify_song_subject/application/AlbumStatisticsQueryServiceTest.java
@@ -153,14 +153,11 @@ class AlbumStatisticsQueryServiceTest {
 
         List<AlbumStatisticsDto> dtoList = Arrays.asList(
             AlbumStatisticsDto.builder()
-                .albumId(100L)
-                .albumName("Test Album")
                 .artistId(1L)
                 .artistName("Test Artist")
                 .releaseDate(releaseDate)
                 .releaseYear(2023)
                 .albumCount(1L)
-                .songCount(12L)
                 .build()
         );
 
@@ -176,14 +173,11 @@ class AlbumStatisticsQueryServiceTest {
         StepVerifier.create(result)
             .assertNext(page -> {
                 AlbumStatisticsDto dto = page.getContent().get(0);
-                assertThat(dto.getAlbumId()).isEqualTo(100L);
-                assertThat(dto.getAlbumName()).isEqualTo("Test Album");
                 assertThat(dto.getArtistId()).isEqualTo(1L);
                 assertThat(dto.getArtistName()).isEqualTo("Test Artist");
                 assertThat(dto.getReleaseDate()).isEqualTo(releaseDate);
                 assertThat(dto.getReleaseYear()).isEqualTo(2023);
                 assertThat(dto.getAlbumCount()).isEqualTo(1L);
-                assertThat(dto.getSongCount()).isEqualTo(12L);
             })
             .verifyComplete();
     }

--- a/src/test/java/com/example/spotify_song_subject/application/ArtistBatchProcessorTest.java
+++ b/src/test/java/com/example/spotify_song_subject/application/ArtistBatchProcessorTest.java
@@ -1,0 +1,170 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.Artist;
+import com.example.spotify_song_subject.repository.ArtistRepository;
+import com.example.spotify_song_subject.repository.bulk.ArtistBulkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("ArtistBatchProcessor 단위 테스트")
+class ArtistBatchProcessorTest {
+
+    private ArtistRepository artistRepository;
+    private ArtistBulkRepository artistBulkRepository;
+
+    private ArtistBatchProcessor artistBatchProcessor;
+
+    private Set<String> artistNames;
+    private Map<String, Artist> existingArtists;
+    private List<Artist> newArtists;
+
+    @BeforeEach
+    void setUp() {
+        this.artistRepository = mock(ArtistRepository.class);
+        this.artistBulkRepository = mock(ArtistBulkRepository.class);
+        this.artistBatchProcessor = new ArtistBatchProcessor(artistRepository, artistBulkRepository);
+
+        artistNames = new HashSet<>(Arrays.asList("Artist1", "Artist2", "Artist3"));
+        existingArtists = new HashMap<>();
+        existingArtists.put("Artist1", createArtist(1L, "Artist1"));
+        
+        newArtists = Arrays.asList(
+            createArtist(2L, "Artist2"),
+            createArtist(3L, "Artist3")
+        );
+    }
+
+    @Test
+    @DisplayName("빈 아티스트 이름 세트를 처리하면 빈 맵을 반환한다")
+    void processEmptyArtistNames() {
+        // given
+        Set<String> emptySet = Collections.emptySet();
+
+        // when & then
+        StepVerifier.create(artistBatchProcessor.processArtistsBatch(emptySet))
+            .assertNext(result -> {
+                assertThat(result).isEmpty();
+            })
+            .verifyComplete();
+
+        verify(artistRepository, never()).findAllByNameIn(any());
+        verify(artistBulkRepository, never()).bulkInsert(any());
+    }
+
+    @Test
+    @DisplayName("모든 아티스트가 이미 존재하면 기존 아티스트 맵을 반환한다")
+    void processExistingArtists() {
+        // given
+        Map<String, Artist> allExisting = new HashMap<>();
+        allExisting.put("Artist1", createArtist(1L, "Artist1"));
+        allExisting.put("Artist2", createArtist(2L, "Artist2"));
+        allExisting.put("Artist3", createArtist(3L, "Artist3"));
+
+        // processArtistsBatchFast 방식에서는 항상 bulkInsert를 시도함
+        when(artistBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(0L)); // 이미 존재하므로 0개 삽입
+
+        when(artistRepository.findAllByNameIn(artistNames))
+            .thenReturn(Flux.fromIterable(allExisting.values()));
+
+        // when & then
+        StepVerifier.create(artistBatchProcessor.processArtistsBatch(artistNames))
+            .assertNext(result -> {
+                assertThat(result).hasSize(3);
+                assertThat(result).containsAllEntriesOf(allExisting);
+            })
+            .verifyComplete();
+
+        verify(artistBulkRepository).bulkInsert(any());
+    }
+
+    @Test
+    @DisplayName("새로운 아티스트만 bulk insert하고 전체 맵을 반환한다")
+    void processNewArtists() {
+        // given
+        // processArtistsBatchFast에서는 모든 아티스트를 INSERT IGNORE로 시도
+        when(artistBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(2L)); // 2개가 새로 삽입됨
+
+        // 전체 아티스트 조회 시 모든 아티스트 반환
+        Map<String, Artist> allArtists = new HashMap<>();
+        allArtists.put("Artist1", createArtist(1L, "Artist1"));
+        allArtists.put("Artist2", createArtist(2L, "Artist2"));
+        allArtists.put("Artist3", createArtist(3L, "Artist3"));
+
+        when(artistRepository.findAllByNameIn(artistNames))
+            .thenReturn(Flux.fromIterable(allArtists.values()));
+
+        // when & then
+        StepVerifier.create(artistBatchProcessor.processArtistsBatch(artistNames))
+            .assertNext(result -> {
+                assertThat(result).hasSize(3);
+                assertThat(result).containsKeys("Artist1", "Artist2", "Artist3");
+                assertThat(result.get("Artist1").getId()).isEqualTo(1L);
+                assertThat(result.get("Artist2").getId()).isEqualTo(2L);
+                assertThat(result.get("Artist3").getId()).isEqualTo(3L);
+            })
+            .verifyComplete();
+
+        // processArtistsBatchFast는 모든 아티스트를 bulk insert 시도
+        verify(artistBulkRepository).bulkInsert(argThat(artists -> 
+            artists.size() == 3 && 
+            artists.stream().map(Artist::getName).collect(Collectors.toSet()).equals(artistNames)
+        ));
+    }
+
+    @Test
+    @DisplayName("bulk insert 실패 시 에러를 전파한다")
+    void handleBulkInsertError() {
+        // given
+        // processArtistsBatchFast에서는 모든 아티스트를 bulk insert 시도
+        when(artistBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.error(new RuntimeException("Bulk insert failed")));
+
+        // bulk insert가 실패하면 findAllByNameIn이 호출되지 않지만, 
+        // 에러 처리 과정에서 호출될 수 있으므로 설정
+        when(artistRepository.findAllByNameIn(anySet()))
+            .thenReturn(Flux.empty());
+
+        // when & then
+        StepVerifier.create(artistBatchProcessor.processArtistsBatch(artistNames))
+            .expectErrorMessage("Bulk insert failed")
+            .verify();
+    }
+
+    @Test
+    @DisplayName("재조회 실패 시 에러를 전파한다")
+    void handleReloadError() {
+        // given
+        // processArtistsBatchFast에서는 bulk insert 후 전체를 다시 조회
+        when(artistBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(2L));
+
+        // 재조회 시 에러 발생
+        when(artistRepository.findAllByNameIn(artistNames))
+            .thenReturn(Flux.error(new RuntimeException("Reload failed")));
+
+        // when & then
+        StepVerifier.create(artistBatchProcessor.processArtistsBatch(artistNames))
+            .expectErrorMessage("Reload failed")
+            .verify();
+    }
+
+    private Artist createArtist(Long id, String name) {
+        Artist artist = Artist.of(name);
+        ReflectionTestUtils.setField(artist, "id", id);
+        return artist;
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/application/RelationshipDataProcessorTest.java
+++ b/src/test/java/com/example/spotify_song_subject/application/RelationshipDataProcessorTest.java
@@ -1,0 +1,287 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.*;
+import com.example.spotify_song_subject.dto.SimilarSongDto;
+import com.example.spotify_song_subject.dto.SpotifySongDto;
+import com.example.spotify_song_subject.repository.bulk.ArtistAlbumBulkRepository;
+import com.example.spotify_song_subject.repository.bulk.ArtistSongBulkRepository;
+import com.example.spotify_song_subject.repository.bulk.SimilarSongBulkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("RelationshipDataProcessor 단위 테스트")
+class RelationshipDataProcessorTest {
+
+    private ArtistSongBulkRepository artistSongBulkRepository;
+    private ArtistAlbumBulkRepository artistAlbumBulkRepository;
+    private SimilarSongBulkRepository similarSongBulkRepository;
+
+    private RelationshipDataProcessor relationshipDataProcessor;
+
+    @BeforeEach
+    void setUp() {
+        this.artistSongBulkRepository = mock(ArtistSongBulkRepository.class);
+        this.artistAlbumBulkRepository = mock(ArtistAlbumBulkRepository.class);
+        this.similarSongBulkRepository = mock(SimilarSongBulkRepository.class);
+
+        this.relationshipDataProcessor = new RelationshipDataProcessor(
+            artistSongBulkRepository,
+            artistAlbumBulkRepository,
+            similarSongBulkRepository
+        );
+    }
+
+    @Test
+    @DisplayName("빈 데이터로 빈 RelationshipData를 반환한다")
+    void buildRelationshipsWithEmptyData() {
+        // given
+        List<Song> emptySongs = Collections.emptyList();
+        List<SpotifySongDto> emptyDtos = Collections.emptyList();
+        Map<String, Artist> emptyArtistsMap = Collections.emptyMap();
+        Map<String, Album> emptyAlbumsMap = Collections.emptyMap();
+        Map<Integer, String> emptySongIndexMap = Collections.emptyMap();
+
+        // when
+        RelationshipDataProcessor.RelationshipData result = RelationshipDataProcessor.buildRelationships(
+            emptySongs, emptyDtos, emptyArtistsMap, emptyAlbumsMap, emptySongIndexMap
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.artistSongs()).isEmpty();
+        assertThat(result.artistAlbums()).isEmpty();
+        assertThat(result.similarSongs()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("아티스트-노래 관계를 올바르게 생성한다")
+    void buildArtistSongRelationships() {
+        // given
+        Song song1 = createSongWithId(1L, "Song 1", 100L);
+        Song song2 = createSongWithId(2L, "Song 2", 101L);
+
+        SpotifySongDto dto1 = createSpotifySongDto("Song 1", Arrays.asList("Artist 1", "Artist 2"));
+        SpotifySongDto dto2 = createSpotifySongDto("Song 2", Arrays.asList("Artist 1"));
+
+        Map<String, Artist> artistsMap = new HashMap<>();
+        artistsMap.put("Artist 1", createArtistWithId(10L, "Artist 1"));
+        artistsMap.put("Artist 2", createArtistWithId(11L, "Artist 2"));
+
+        Map<String, Album> albumsMap = new HashMap<>();
+        albumsMap.put("Album 1|2023-01-01", createAlbumWithId(100L));
+        albumsMap.put("Album 2|2023-01-01", createAlbumWithId(101L));
+
+        Map<Integer, String> songIndexToAlbumKey = new HashMap<>();
+        songIndexToAlbumKey.put(0, "Album 1|2023-01-01");
+        songIndexToAlbumKey.put(1, "Album 2|2023-01-01");
+
+        // when
+        RelationshipDataProcessor.RelationshipData result = RelationshipDataProcessor.buildRelationships(
+            Arrays.asList(song1, song2),
+            Arrays.asList(dto1, dto2),
+            artistsMap,
+            albumsMap,
+            songIndexToAlbumKey
+        );
+
+        // then
+        assertThat(result.artistSongs()).hasSize(3);
+        assertThat(result.artistSongs())
+            .extracting(as -> as.getArtistId() + ":" + as.getSongId())
+            .containsExactlyInAnyOrder("10:1", "11:1", "10:2");
+    }
+
+    @Test
+    @DisplayName("아티스트-앨범 관계를 중복 없이 생성한다")
+    void buildArtistAlbumRelationshipsWithoutDuplicates() {
+        // given
+        Song song1 = createSongWithId(1L, "Song 1", 100L);
+        Song song2 = createSongWithId(2L, "Song 2", 100L); // Same album
+
+        SpotifySongDto dto1 = createSpotifySongDto("Song 1", Arrays.asList("Artist 1"));
+        SpotifySongDto dto2 = createSpotifySongDto("Song 2", Arrays.asList("Artist 1")); // Same artist
+
+        Map<String, Artist> artistsMap = new HashMap<>();
+        artistsMap.put("Artist 1", createArtistWithId(10L, "Artist 1"));
+
+        Map<String, Album> albumsMap = new HashMap<>();
+        albumsMap.put("Album 1|2023-01-01", createAlbumWithId(100L));
+
+        Map<Integer, String> songIndexToAlbumKey = new HashMap<>();
+        songIndexToAlbumKey.put(0, "Album 1|2023-01-01");
+        songIndexToAlbumKey.put(1, "Album 1|2023-01-01");
+
+        // when
+        RelationshipDataProcessor.RelationshipData result = RelationshipDataProcessor.buildRelationships(
+            Arrays.asList(song1, song2),
+            Arrays.asList(dto1, dto2),
+            artistsMap,
+            albumsMap,
+            songIndexToAlbumKey
+        );
+
+        // then
+        assertThat(result.artistAlbums()).hasSize(1); // Should not have duplicates
+        assertThat(result.artistAlbums().get(0).getArtistId()).isEqualTo(10L);
+        assertThat(result.artistAlbums().get(0).getAlbumId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("유사 노래 관계를 올바르게 생성한다")
+    void buildSimilarSongRelationships() {
+        // given
+        Song song1 = createSongWithId(1L, "Song 1", 100L);
+
+        List<SimilarSongDto> similarSongs = Arrays.asList(
+            createSimilarSongDto("Similar Artist 1", "Similar Song 1", new BigDecimal("0.95")),
+            createSimilarSongDto("Similar Artist 2", "Similar Song 2", new BigDecimal("0.85"))
+        );
+
+        SpotifySongDto dto1 = createSpotifySongDtoWithSimilar("Song 1", Arrays.asList("Artist 1"), similarSongs);
+
+        Map<String, Artist> artistsMap = new HashMap<>();
+        artistsMap.put("Artist 1", createArtistWithId(10L, "Artist 1"));
+
+        Map<String, Album> albumsMap = new HashMap<>();
+        albumsMap.put("Album 1|2023-01-01", createAlbumWithId(100L));
+
+        Map<Integer, String> songIndexToAlbumKey = new HashMap<>();
+        songIndexToAlbumKey.put(0, "Album 1|2023-01-01");
+
+        // when
+        RelationshipDataProcessor.RelationshipData result = RelationshipDataProcessor.buildRelationships(
+            Arrays.asList(song1),
+            Arrays.asList(dto1),
+            artistsMap,
+            albumsMap,
+            songIndexToAlbumKey
+        );
+
+        // then
+        assertThat(result.similarSongs()).hasSize(2);
+        assertThat(result.similarSongs())
+            .extracting(SimilarSong::getSimilarArtistName)
+            .containsExactlyInAnyOrder("Similar Artist 1", "Similar Artist 2");
+        assertThat(result.similarSongs())
+            .extracting(SimilarSong::getSimilarityScore)
+            .containsExactlyInAnyOrder(new BigDecimal("0.95"), new BigDecimal("0.85"));
+    }
+
+    @Test
+    @DisplayName("원본 DTO를 찾지 못한 경우 경고 로그를 남기고 건너뛴다")
+    void skipWhenOriginalDtoNotFound() {
+        // given
+        Song song1 = createSongWithId(1L, "Song 1", 100L);
+
+        // Empty DTOs list
+        List<SpotifySongDto> emptyDtos = Collections.emptyList();
+
+        Map<String, Artist> artistsMap = new HashMap<>();
+        artistsMap.put("Artist 1", createArtistWithId(10L, "Artist 1"));
+
+        Map<String, Album> albumsMap = new HashMap<>();
+        albumsMap.put("Album 1|2023-01-01", createAlbumWithId(100L));
+
+        Map<Integer, String> songIndexToAlbumKey = new HashMap<>();
+
+        // when
+        RelationshipDataProcessor.RelationshipData result = RelationshipDataProcessor.buildRelationships(
+            Arrays.asList(song1),
+            emptyDtos,
+            artistsMap,
+            albumsMap,
+            songIndexToAlbumKey
+        );
+
+        // then
+        assertThat(result.artistSongs()).isEmpty();
+        assertThat(result.artistAlbums()).isEmpty();
+        assertThat(result.similarSongs()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("repository getter 메소드들이 정상 작동한다")
+    void repositoryGettersWork() {
+        // then
+        // Repository 주입 확인은 bulk insert 메서드 호출로 간접적으로 테스트
+        assertThat(relationshipDataProcessor).isNotNull();
+    }
+
+    // Helper methods
+    private Song createSongWithId(Long id, String title, Long albumId) {
+        Song song = Song.builder()
+            .title(title)
+            .albumId(albumId)
+            .build();
+        // Simulate persisted entity with reflection
+        try {
+            java.lang.reflect.Field idField = song.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(song, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return song;
+    }
+
+    private Artist createArtistWithId(Long id, String name) {
+        Artist artist = Artist.of(name);
+        // Simulate persisted entity with reflection
+        try {
+            java.lang.reflect.Field idField = artist.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(artist, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return artist;
+    }
+
+    private Album createAlbumWithId(Long id) {
+        Album album = Album.of("Album", LocalDate.of(2023, 1, 1));
+        // Simulate persisted entity with reflection
+        try {
+            java.lang.reflect.Field idField = album.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(album, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return album;
+    }
+
+    private SpotifySongDto createSpotifySongDto(String title, List<String> artists) {
+        return SpotifySongDto.builder()
+            .songTitle(title)
+            .artists(String.join(", ", artists))
+            .albumTitle("Album 1")
+            .releaseDate("2023-01-01")
+            .build();
+    }
+
+    private SpotifySongDto createSpotifySongDtoWithSimilar(String title, List<String> artists, List<SimilarSongDto> similarSongs) {
+        return SpotifySongDto.builder()
+            .songTitle(title)
+            .artists(String.join(", ", artists))
+            .albumTitle("Album 1")
+            .releaseDate("2023-01-01")
+            .similarSongs(similarSongs)
+            .build();
+    }
+
+    private SimilarSongDto createSimilarSongDto(String artistName, String songTitle, BigDecimal score) {
+        return SimilarSongDto.builder()
+            .artistName(artistName)
+            .songTitle(songTitle)
+            .similarityScore(score)
+            .build();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/application/SongBatchProcessorTest.java
+++ b/src/test/java/com/example/spotify_song_subject/application/SongBatchProcessorTest.java
@@ -1,0 +1,345 @@
+package com.example.spotify_song_subject.application;
+
+import com.example.spotify_song_subject.domain.Album;
+import com.example.spotify_song_subject.domain.Song;
+import com.example.spotify_song_subject.dto.SpotifySongDto;
+import com.example.spotify_song_subject.repository.SongRepository;
+import com.example.spotify_song_subject.repository.bulk.SongBulkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("SongBatchProcessor 단위 테스트")
+class SongBatchProcessorTest {
+
+    private SongRepository songRepository;
+    private SongBulkRepository songBulkRepository;
+
+    private SongBatchProcessor songBatchProcessor;
+
+    private List<SpotifySongDto> songDtos;
+    private Map<String, Album> albumsMap;
+    private List<Song> expectedSongs;
+
+    @BeforeEach
+    void setUp() {
+        this.songRepository = mock(SongRepository.class);
+        this.songBulkRepository = mock(SongBulkRepository.class);
+        this.songBatchProcessor = new SongBatchProcessor(songRepository, songBulkRepository);
+
+        songDtos = Arrays.asList(
+            createSongDto("Song1", "Album1", "2023-01-01", "Artist1"),
+            createSongDto("Song2", "Album1", "2023-01-01", "Artist1"),
+            createSongDto("Song3", "Album2", "2023-02-01", "Artist2")
+        );
+
+        albumsMap = new HashMap<>();
+        albumsMap.put("Album1|2023-01-01|Artist1", createAlbum(1L, "Album1", LocalDate.of(2023, 1, 1), "Artist1"));
+        albumsMap.put("Album2|2023-02-01|Artist2", createAlbum(2L, "Album2", LocalDate.of(2023, 2, 1), "Artist2"));
+
+        expectedSongs = Arrays.asList(
+            createSong(1L, "Song1", 1L),
+            createSong(2L, "Song2", 1L),
+            createSong(3L, "Song3", 2L)
+        );
+    }
+
+    @Test
+    @DisplayName("빈 songDtos 리스트를 처리하면 빈 결과를 반환한다")
+    void processEmptySongDtos() {
+        // given
+        List<SpotifySongDto> emptyList = Collections.emptyList();
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(emptyList, albumsMap))
+            .assertNext(result -> {
+                assertThat(result.savedSongs()).isEmpty();
+                assertThat(result.songIndexToAlbumKey()).isEmpty();
+            })
+            .verifyComplete();
+
+        verify(songBulkRepository, never()).bulkInsert(any());
+        verify(songRepository, never()).findAllByTitleIn(any());
+    }
+
+    @Test
+    @DisplayName("빈 albumsMap을 처리해도 album_id 없이 songs를 저장한다")
+    void processEmptyAlbumsMap() {
+        // given
+        Map<String, Album> emptyMap = Collections.emptyMap();
+
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(3L));
+        
+        // title로 조회하지만 결과가 없음
+        when(songRepository.findAllByTitleIn(anyCollection()))
+            .thenReturn(Flux.empty());
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(songDtos, emptyMap))
+            .assertNext(result -> {
+                assertThat(result.savedSongs()).isEmpty(); // title로 조회했지만 결과가 없음
+                assertThat(result.songIndexToAlbumKey()).hasSize(3);
+                assertThat(result.songIndexToAlbumKey().values()).allMatch(Objects::isNull);
+            })
+            .verifyComplete();
+
+        verify(songBulkRepository).bulkInsert(argThat(songs -> 
+            songs.size() == 3 && 
+            songs.stream().allMatch(song -> song.getAlbumId() == null)
+        ));
+    }
+
+    @Test
+    @DisplayName("정상적으로 songs를 bulk insert하고 재조회한다")
+    void processNormalSongs() {
+        // given
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(3L));
+
+        when(songRepository.findAllByTitleIn(Set.of("Song1", "Song2", "Song3")))
+            .thenReturn(Flux.fromIterable(expectedSongs));
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(songDtos, albumsMap))
+            .assertNext(result -> {
+                assertThat(result.savedSongs()).hasSize(3);
+                assertThat(result.savedSongs()).containsExactlyInAnyOrderElementsOf(expectedSongs);
+                
+                assertThat(result.songIndexToAlbumKey()).hasSize(3);
+                assertThat(result.songIndexToAlbumKey()).containsEntry(0, "Album1|2023-01-01|Artist1");
+                assertThat(result.songIndexToAlbumKey()).containsEntry(1, "Album1|2023-01-01|Artist1");
+                assertThat(result.songIndexToAlbumKey()).containsEntry(2, "Album2|2023-02-01|Artist2");
+            })
+            .verifyComplete();
+
+        verify(songBulkRepository).bulkInsert(argThat(songs -> songs.size() == 3));
+    }
+
+    @Test
+    @DisplayName("일부 songs의 album이 없으면 album_id를 null로 저장한다")
+    void processWithMissingAlbums() {
+        // given
+        // Album2만 있고 Album1은 없는 상황
+        Map<String, Album> partialAlbumsMap = new HashMap<>();
+        partialAlbumsMap.put("Album2|2023-02-01|Artist2", createAlbum(2L, "Album2", LocalDate.of(2023, 2, 1), "Artist2"));
+
+        // Song1, Song2는 album이 없어서 null album_id로 저장, Song3만 album_id 2로 저장
+        List<Song> savedSongs = Arrays.asList(
+            createSong(1L, "Song1", null),  // album 없음
+            createSong(2L, "Song2", null),  // album 없음
+            createSong(3L, "Song3", 2L)     // album 있음
+        );
+
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(3L));  // 3개 모두 저장
+
+        when(songRepository.findAllByTitleIn(Set.of("Song1", "Song2", "Song3")))
+            .thenReturn(Flux.fromIterable(savedSongs));  // 모든 song 반환
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(songDtos, partialAlbumsMap))
+            .assertNext(result -> {
+                assertThat(result.savedSongs()).hasSize(3);  // 모든 song이 저장됨
+                
+                // album이 없는 songs
+                assertThat(result.savedSongs().stream()
+                    .filter(s -> s.getAlbumId() == null)
+                    .count()).isEqualTo(2);
+                
+                // album이 있는 song
+                assertThat(result.savedSongs().stream()
+                    .filter(s -> s.getAlbumId() != null)
+                    .count()).isEqualTo(1);
+                
+                assertThat(result.songIndexToAlbumKey()).hasSize(3);
+                assertThat(result.songIndexToAlbumKey()).containsEntry(0, null);  // Song1 - album 없음
+                assertThat(result.songIndexToAlbumKey()).containsEntry(1, null);  // Song2 - album 없음
+                assertThat(result.songIndexToAlbumKey()).containsEntry(2, "Album2|2023-02-01|Artist2");
+            })
+            .verifyComplete();
+
+        verify(songBulkRepository).bulkInsert(argThat(songs -> songs.size() == 3));
+    }
+
+    @Test
+    @DisplayName("대량의 songs를 효율적으로 처리한다")
+    void processLargeDataSet() {
+        // given
+        List<SpotifySongDto> largeSongDtos = new ArrayList<>();
+        Map<String, Album> largeAlbumsMap = new HashMap<>();
+        List<Song> largeSavedSongs = new ArrayList<>();
+
+        // 1000개의 song 생성
+        for (int i = 0; i < 1000; i++) {
+            String albumTitle = "Album" + (i / 100); // 10개의 앨범
+            String artistName = "Artist" + (i / 100);
+            LocalDate releaseDate = LocalDate.of(2023, 1, 1).plusDays(i / 100);
+            
+            largeSongDtos.add(createSongDto("Song" + i, albumTitle, releaseDate.toString(), artistName));
+            
+            String albumKey = albumTitle + "|" + releaseDate + "|" + artistName;
+            if (!largeAlbumsMap.containsKey(albumKey)) {
+                largeAlbumsMap.put(albumKey, createAlbum((long) (i / 100), albumTitle, releaseDate, artistName));
+            }
+            
+            largeSavedSongs.add(createSong((long) i, "Song" + i, (long) (i / 100)));
+        }
+
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(1000L));
+
+        Set<String> titles = largeSongDtos.stream()
+            .map(SpotifySongDto::getSongTitle)
+            .collect(Collectors.toSet());
+        when(songRepository.findAllByTitleIn(titles))
+            .thenReturn(Flux.fromIterable(largeSavedSongs));
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(largeSongDtos, largeAlbumsMap))
+            .assertNext(result -> {
+                assertThat(result.savedSongs()).hasSize(1000);
+                assertThat(result.songIndexToAlbumKey()).hasSize(1000);
+            })
+            .verifyComplete();
+
+        verify(songBulkRepository).bulkInsert(argThat(songs -> songs.size() == 1000));
+    }
+
+    @Test
+    @DisplayName("bulk insert 실패 시 에러를 전파한다")
+    void handleBulkInsertError() {
+        // given
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.error(new RuntimeException("Bulk insert failed")));
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(songDtos, albumsMap))
+            .expectErrorMessage("Bulk insert failed")
+            .verify();
+    }
+
+    @Test
+    @DisplayName("재조회 실패 시 에러를 전파한다")
+    void handleReloadError() {
+        // given
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(3L));
+
+        when(songRepository.findAllByTitleIn(anySet()))
+            .thenReturn(Flux.error(new RuntimeException("Reload failed")));
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(songDtos, albumsMap))
+            .expectErrorMessage("Reload failed")
+            .verify();
+    }
+
+    @Test
+    @DisplayName("다양한 날짜 포맷을 올바르게 처리한다")
+    void handleVariousDateFormats() {
+        // given
+        List<SpotifySongDto> mixedDateSongs = Arrays.asList(
+            createSongDto("Song1", "Album1", "2023-01-01", "Artist1"),
+            createSongDto("Song2", "Album2", "02/01/2023", "Artist2"),
+            createSongDto("Song3", "Album3", "2023/03/01", "Artist3"),
+            createSongDto("Song4", "Album4", "2023", "Artist4")
+        );
+
+        Map<String, Album> dateAlbumsMap = new HashMap<>();
+        dateAlbumsMap.put("Album1|2023-01-01|Artist1", createAlbum(1L, "Album1", LocalDate.of(2023, 1, 1), "Artist1"));
+        dateAlbumsMap.put("Album2|2023-02-01|Artist2", createAlbum(2L, "Album2", LocalDate.of(2023, 2, 1), "Artist2"));
+        dateAlbumsMap.put("Album3|2023-03-01|Artist3", createAlbum(3L, "Album3", LocalDate.of(2023, 3, 1), "Artist3"));
+        dateAlbumsMap.put("Album4|2023-01-01|Artist4", createAlbum(4L, "Album4", LocalDate.of(2023, 1, 1), "Artist4"));
+
+        List<Song> savedSongs = Arrays.asList(
+            createSong(1L, "Song1", 1L),
+            createSong(2L, "Song2", 2L),
+            createSong(3L, "Song3", 3L),
+            createSong(4L, "Song4", 4L)
+        );
+
+        when(songBulkRepository.bulkInsert(anyList()))
+            .thenReturn(Mono.just(4L));
+
+        when(songRepository.findAllByTitleIn(anySet()))
+            .thenReturn(Flux.fromIterable(savedSongs));
+
+        // when & then
+        StepVerifier.create(songBatchProcessor.processSongsBatch(mixedDateSongs, dateAlbumsMap))
+            .assertNext(result -> {
+                assertThat(result.savedSongs()).hasSize(4);
+                assertThat(result.songIndexToAlbumKey()).hasSize(4);
+            })
+            .verifyComplete();
+    }
+
+    private SpotifySongDto createSongDto(String title, String albumTitle, String releaseDate) {
+        return createSongDto(title, albumTitle, releaseDate, "Unknown Artist");
+    }
+    
+    private SpotifySongDto createSongDto(String title, String albumTitle, String releaseDate, String artists) {
+        SpotifySongDto dto = SpotifySongDto.builder()
+            .songTitle(title)
+            .albumTitle(albumTitle)
+            .releaseDate(releaseDate)
+            .artists(artists)
+            .popularity(50)
+            .explicit("false")
+            .danceability(50)
+            .energy(50)
+            .musicKey("C")
+            .loudnessDb(new BigDecimal("-5.0"))
+            .speechiness(5)
+            .acousticness(30)
+            .instrumentalness(0)
+            .liveness(10)
+            .positiveness(50)
+            .tempo(new BigDecimal("120.0"))
+            .timeSignature("4/4")
+            .build();
+        
+        // songId를 additionalProperties에 추가
+        dto.setAdditionalProperty("uri", "spotify:track:" + title);
+        
+        return dto;
+    }
+
+    private Album createAlbum(Long id, String title, LocalDate releaseDate) {
+        return createAlbum(id, title, releaseDate, "Unknown Artist");
+    }
+    
+    private Album createAlbum(Long id, String title, LocalDate releaseDate, String artistName) {
+        Album album = Album.of(title, releaseDate, artistName);
+        ReflectionTestUtils.setField(album, "id", id);
+        return album;
+    }
+
+    private Song createSong(Long id, String title, Long albumId) {
+        Song song = Song.builder()
+            .title(title)
+            .albumId(albumId)
+            .popularity(50)
+            .energy(50)
+            .tempo(new BigDecimal("120.0"))
+            .loudnessDb(new BigDecimal("-5.0"))
+            .musicKey("C")
+            .timeSignature("4/4")
+            .build();
+        ReflectionTestUtils.setField(song, "id", id);
+        return song;
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/application/SongLikeQueryServiceTest.java
+++ b/src/test/java/com/example/spotify_song_subject/application/SongLikeQueryServiceTest.java
@@ -7,8 +7,6 @@ import com.example.spotify_song_subject.repository.SongLikeCustomRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -20,7 +18,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayName("SongLikeQueryService Unit Tests")
 class SongLikeQueryServiceTest {
 
@@ -273,7 +270,7 @@ class SongLikeQueryServiceTest {
     @Test
     @DisplayName("트렌딩 곡 조회 - 중복 Song ID 처리 (에러 케이스)")
     void getTrendingSongs_DuplicateSongIds() {
-        // Given (실제로는 발생하지 않아야 하지만 방어적 프로그래밍)
+        // Given
         List<SongLikeScore> mockScores = List.of(
             new SongLikeScore(1L, 100L),
             new SongLikeScore(1L, 200L),
@@ -283,7 +280,7 @@ class SongLikeQueryServiceTest {
         when(songLikeRedisRepository.getTop10TrendingSongs())
             .thenReturn(Mono.just(mockScores));
 
-        // When & Then - 중복 키로 인한 에러가 발생하고 빈 리스트 반환
+        // When & Then
         StepVerifier.create(songLikeQueryService.getTrendingSongs())
             .assertNext(result -> assertThat(result).isEmpty())
             .verifyComplete();

--- a/src/test/java/com/example/spotify_song_subject/controller/AlbumStatisticsControllerTest.java
+++ b/src/test/java/com/example/spotify_song_subject/controller/AlbumStatisticsControllerTest.java
@@ -237,14 +237,11 @@ class AlbumStatisticsControllerTest {
 
         List<AlbumStatisticsDto> dtoList = Arrays.asList(
             AlbumStatisticsDto.builder()
-                .albumId(100L)
-                .albumName("Test Album")
                 .artistId(1L)
                 .artistName("Test Artist")
                 .releaseDate(releaseDate)
                 .releaseYear(2023)
                 .albumCount(1L)
-                .songCount(10L)
                 .build()
         );
 
@@ -261,15 +258,12 @@ class AlbumStatisticsControllerTest {
             .exchange()
             .expectStatus().isOk()
             .expectBody()
-            .jsonPath("$.content[0].albumId").isEqualTo(100)
-            .jsonPath("$.content[0].albumName").isEqualTo("Test Album")
             .jsonPath("$.content[0].artistId").isEqualTo(1)
             .jsonPath("$.content[0].artistName").isEqualTo("Test Artist")
             .jsonPath("$.content[0].releaseDate[0]").isEqualTo(2023)
             .jsonPath("$.content[0].releaseDate[1]").isEqualTo(3)
             .jsonPath("$.content[0].releaseDate[2]").isEqualTo(15)
             .jsonPath("$.content[0].releaseYear").isEqualTo(2023)
-            .jsonPath("$.content[0].albumCount").isEqualTo(1)
-            .jsonPath("$.content[0].songCount").isEqualTo(10);
+            .jsonPath("$.content[0].albumCount").isEqualTo(1);
     }
 }

--- a/src/test/java/com/example/spotify_song_subject/dto/BatchContextTest.java
+++ b/src/test/java/com/example/spotify_song_subject/dto/BatchContextTest.java
@@ -1,0 +1,265 @@
+package com.example.spotify_song_subject.dto;
+
+import com.example.spotify_song_subject.application.AlbumBatchProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("BatchContext 테스트")
+class BatchContextTest {
+
+    @Nested
+    @DisplayName("from 메서드 테스트")
+    class FromMethodTest {
+
+        @Test
+        @DisplayName("정상적인 DTO 리스트로 BatchContext 생성")
+        void shouldCreateBatchContextFromValidDtos() {
+            // given
+            List<SpotifySongDto> dtos = Arrays.asList(
+                createSongDto("Artist1, Artist2", "Album1", "2023-01-15"),
+                createSongDto("Artist2, Artist3", "Album2", "2023-02-20"),
+                createSongDto("Artist1", "Album1", "2023-01-15")
+            );
+
+            // when
+            BatchContext context = BatchContext.from(dtos);
+
+            // then
+            assertThat(context.artistNames())
+                .containsExactlyInAnyOrder("Artist1", "Artist2", "Artist3");
+            assertThat(context.albumsByTitle())
+                .hasSize(2)
+                .containsKeys("Album1", "Album2");
+            
+            assertThat(context.albumsByTitle().get("Album1"))
+                .hasSize(2)  // "Artist1, Artist2"와 "Artist1"로 두 개의 서로 다른 앨범 정보
+                .anySatisfy(info -> {
+                    assertThat(info.releaseDate()).isEqualTo(LocalDate.of(2023, 1, 15));
+                    assertThat(info.artistName()).isEqualTo("Artist1, Artist2");
+                })
+                .anySatisfy(info -> {
+                    assertThat(info.releaseDate()).isEqualTo(LocalDate.of(2023, 1, 15));
+                    assertThat(info.artistName()).isEqualTo("Artist1");
+                });
+                
+            assertThat(context.songs()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("null과 빈 리스트 처리")
+        void shouldReturnEmptyContextForNullOrEmptyList() {
+            // null list
+            BatchContext nullContext = BatchContext.from(null);
+            assertThat(nullContext.artistNames()).isEmpty();
+            assertThat(nullContext.albumsByTitle()).isEmpty();
+            assertThat(nullContext.songs()).isEmpty();
+
+            // empty list
+            BatchContext emptyContext = BatchContext.from(new ArrayList<>());
+            assertThat(emptyContext.artistNames()).isEmpty();
+            assertThat(emptyContext.albumsByTitle()).isEmpty();
+            assertThat(emptyContext.songs()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("아티스트 처리 테스트")
+    class ArtistProcessingTest {
+
+        @Test
+        @DisplayName("아티스트 이름 파싱 및 정규화")
+        void shouldParseAndNormalizeArtistNames() {
+            // given - 다양한 형태의 아티스트 입력
+            List<SpotifySongDto> dtos = Arrays.asList(
+                createSongDto("  Artist1  ,   Artist2   ,Artist3  ", null, null), // 공백 포함
+                createSongDto("Artist1, Artist2", null, null), // 중복
+                createSongDto("Artist4", null, null) // 단일 아티스트
+            );
+
+            // when
+            BatchContext context = BatchContext.from(dtos);
+
+            // then
+            assertThat(context.artistNames())
+                .hasSize(4) // 중복 제거됨
+                .containsExactlyInAnyOrder("Artist1", "Artist2", "Artist3", "Artist4");
+        }
+
+        @Test
+        @DisplayName("빈 아티스트 항목 처리")
+        void shouldHandleEmptyArtistEntries() {
+            // given - null, 빈 문자열, 공백만 있는 경우
+            List<SpotifySongDto> dtos = Arrays.asList(
+                createSongDto(null, null, null),
+                createSongDto("", null, null),
+                createSongDto("   ", null, null)
+            );
+
+            // when
+            BatchContext context = BatchContext.from(dtos);
+
+            // then
+            assertThat(context.artistNames()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"Artist1,,Artist2", "Artist1, ,Artist2", ",Artist1,Artist2,"})
+        @DisplayName("빈 아티스트 항목 무시")
+        void shouldIgnoreEmptyArtistEntries(String artists) {
+            // given
+            List<SpotifySongDto> dtos = Collections.singletonList(
+                createSongDto(artists, null, null)
+            );
+
+            // when
+            BatchContext context = BatchContext.from(dtos);
+
+            // then - 빈 항목은 무시하고 실제 아티스트만 추출
+            assertThat(context.artistNames())
+                .containsExactlyInAnyOrder("Artist1", "Artist2");
+        }
+    }
+
+    @Nested
+    @DisplayName("앨범 처리 테스트")
+    class AlbumProcessingTest {
+
+        @Test
+        @DisplayName("앨범 정보 유효성 검증")
+        void shouldValidateAlbumInfo() {
+            // given - 다양한 앨범 정보 상태
+            List<SpotifySongDto> dtos = Arrays.asList(
+                createSongDto("Artist1", "ValidAlbum", "2023-03-15"), // 정상
+                createSongDto("Artist2", null, "2023-03-15"), // 타이틀 없음 - 무시됨
+                createSongDto("Artist3", "AlbumNoDate", null), // 날짜 없음 - 포함됨 (null 날짜 허용)
+                createSongDto("Artist4", "", "2023-03-15"), // 빈 타이틀 - 무시됨
+                createSongDto("Artist5", "   ", "2023-03-15") // 공백만 있는 타이틀 - 무시됨
+            );
+
+            // when
+            BatchContext context = BatchContext.from(dtos);
+
+            // then - 유효한 앨범만 포함됨
+            assertThat(context.albumsByTitle()).hasSize(2); // ValidAlbum과 AlbumNoDate
+            assertThat(context.albumsByTitle()).containsKeys("ValidAlbum", "AlbumNoDate");
+            
+            // ValidAlbum 확인
+            assertThat(context.albumsByTitle().get("ValidAlbum"))
+                .hasSize(1)
+                .anySatisfy(info -> {
+                    assertThat(info.releaseDate()).isEqualTo(LocalDate.of(2023, 3, 15));
+                    assertThat(info.artistName()).isEqualTo("Artist1");
+                });
+            
+            // AlbumNoDate 확인 (null 날짜 허용)
+            assertThat(context.albumsByTitle().get("AlbumNoDate"))
+                .hasSize(1)
+                .anySatisfy(info -> {
+                    assertThat(info.releaseDate()).isNull();
+                    assertThat(info.artistName()).isEqualTo("Artist3");
+                });
+        }
+
+        @Test
+        @DisplayName("잘못된 날짜 형식 처리")
+        void shouldHandleInvalidDateFormat() {
+            // given
+            SpotifySongDto dto = SpotifySongDto.builder()
+                .albumTitle("Album Title")
+                .releaseDate("invalid-date")
+                .build();
+
+            // when & then - 예외 없이 처리 (SpotifyDomainMapper가 null 반환 가정)
+            assertThatCode(() -> BatchContext.from(Collections.singletonList(dto)))
+                .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder 및 empty 메서드 테스트")
+    class BuilderTest {
+
+        @Test
+        @DisplayName("empty 메서드로 빈 컨텍스트 생성")
+        void shouldCreateEmptyBatchContext() {
+            // when
+            BatchContext context = BatchContext.empty();
+
+            // then
+            assertThat(context.artistNames()).isNotNull().isEmpty();
+            assertThat(context.albumsByTitle()).isNotNull().isEmpty();
+            assertThat(context.songs()).isNotNull().isEmpty();
+        }
+
+        @Test
+        @DisplayName("Builder로 커스텀 컨텍스트 생성")
+        void shouldCreateCustomBatchContext() {
+            // given
+            Set<String> artists = Set.of("Artist1", "Artist2");
+            Map<String, Set<AlbumBatchProcessor.AlbumInfo>> albums = Map.of(
+                "Album1", Set.of(new AlbumBatchProcessor.AlbumInfo(LocalDate.of(2023, 1, 1), "Artist1"))
+            );
+            List<SpotifySongDto> songs = new ArrayList<>();
+
+            // when
+            BatchContext context = BatchContext.builder()
+                .artistNames(artists)
+                .albumsByTitle(albums)
+                .songs(songs)
+                .build();
+
+            // then
+            assertThat(context.artistNames()).isEqualTo(artists);
+            assertThat(context.albumsByTitle()).isEqualTo(albums);
+            assertThat(context.songs()).isEqualTo(songs);
+        }
+    }
+
+    @Nested
+    @DisplayName("통합 시나리오 테스트")
+    class IntegrationTest {
+
+        @Test
+        @DisplayName("실제 복잡한 데이터 처리")
+        void shouldProcessComplexRealWorldData() {
+            // given - K-POP 실제 데이터 시뮬레이션
+            List<SpotifySongDto> dtos = Arrays.asList(
+                createSongDto("BTS, Halsey", "MAP OF THE SOUL : PERSONA", "2019-04-12"),
+                createSongDto("BTS", "MAP OF THE SOUL : PERSONA", "2019-04-12"),
+                createSongDto("IU, SUGA", "Eight", "2020-05-06"),
+                createSongDto("IU", "Love poem", "2019-11-18"),
+                createSongDto(null, null, null), // 빈 데이터
+                createSongDto("", "", ""), // 빈 문자열
+                createSongDto("BLACKPINK, Dua Lipa", "THE ALBUM", "2020-10-02")
+            );
+
+            // when
+            BatchContext context = BatchContext.from(dtos);
+
+            // then
+            assertThat(context.artistNames())
+                .containsExactlyInAnyOrder("BTS", "Halsey", "IU", "SUGA", "BLACKPINK", "Dua Lipa");
+            assertThat(context.albumsByTitle())
+                .hasSize(4)
+                .containsKeys("MAP OF THE SOUL : PERSONA", "Eight", "Love poem", "THE ALBUM");
+            assertThat(context.songs()).hasSize(7);
+        }
+    }
+
+    // Helper method
+    private SpotifySongDto createSongDto(String artists, String albumTitle, String releaseDate) {
+        return SpotifySongDto.builder()
+            .artists(artists)
+            .albumTitle(albumTitle)
+            .releaseDate(releaseDate)
+            .build();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/dto/SimilarSongDtoTest.java
+++ b/src/test/java/com/example/spotify_song_subject/dto/SimilarSongDtoTest.java
@@ -1,0 +1,145 @@
+package com.example.spotify_song_subject.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SimilarSongDto 테스트")
+class SimilarSongDtoTest {
+
+    @Test
+    @DisplayName("setDynamicProperty - Similar Artist 필드 파싱")
+    void shouldParseSimilarArtistField() {
+        // given
+        SimilarSongDto dto = new SimilarSongDto();
+
+        // when
+        dto.setDynamicProperty("Similar Artist 1", "IU");
+        dto.setDynamicProperty("Similar Artist 2", "BTS");
+
+        // then
+        assertThat(dto.getArtistName()).isEqualTo("BTS"); // 마지막 값으로 덮어씀
+    }
+
+    @Test
+    @DisplayName("setDynamicProperty - Similar Song 필드 파싱")
+    void shouldParseSimilarSongField() {
+        // given
+        SimilarSongDto dto = new SimilarSongDto();
+
+        // when
+        dto.setDynamicProperty("Similar Song 1", "Eight");
+        dto.setDynamicProperty("Similar Song 5", "Lilac");
+
+        // then
+        assertThat(dto.getSongTitle()).isEqualTo("Lilac"); // 마지막 값으로 덮어씀
+    }
+
+    @Test
+    @DisplayName("setDynamicProperty - 기타 필드는 properties에 저장")
+    void shouldStoreOtherFieldsInProperties() {
+        // given
+        SimilarSongDto dto = new SimilarSongDto();
+
+        // when
+        dto.setDynamicProperty("Custom Field", "custom value");
+        dto.setDynamicProperty("Extra Data", 123);
+
+        // then
+        assertThat(dto.getProperty("Custom Field")).isEqualTo("custom value");
+        assertThat(dto.getProperty("Extra Data")).isEqualTo(123);
+        assertThat(dto.getArtistName()).isNull(); // Similar Artist가 아니므로 null
+        assertThat(dto.getSongTitle()).isNull(); // Similar Song이 아니므로 null
+    }
+
+    @Test
+    @DisplayName("setDynamicProperty - null properties Map 초기화")
+    void shouldInitializeNullPropertiesMap() {
+        // given
+        SimilarSongDto dto = new SimilarSongDto();
+
+        // when
+        dto.setDynamicProperty("key", "value");
+
+        // then
+        assertThat(dto.getProperties()).isNotNull();
+        assertThat(dto.getProperty("key")).isEqualTo("value");
+    }
+
+    @Test
+    @DisplayName("getProperty - 존재하지 않는 키 조회")
+    void shouldReturnNullForNonExistentKey() {
+        // given
+        SimilarSongDto dto = SimilarSongDto.builder()
+            .properties(null)
+            .build();
+
+        // then
+        assertThat(dto.getProperty("non-existent")).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "Artist1, Song1, 0.95, true",    // 모든 필수 필드 있음
+        ", Song1, 0.95, false",          // artistName 없음
+        "Artist1, , 0.95, false",        // songTitle 없음
+        "Artist1, Song1, , false",       // similarityScore 없음
+        ", , , false"                    // 모든 필드 없음
+    })
+    @DisplayName("isValid - 유효성 검증")
+    void shouldValidateRequiredFields(String artist, String song, BigDecimal score, boolean expected) {
+        // given
+        SimilarSongDto dto = SimilarSongDto.builder()
+            .artistName(artist)
+            .songTitle(song)
+            .similarityScore(score)
+            .build();
+
+        // when
+        boolean result = dto.isValid();
+
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Builder로 완전한 DTO 생성")
+    void shouldCreateCompleteDtoWithBuilder() {
+        // given & when
+        SimilarSongDto dto = SimilarSongDto.builder()
+            .artistName("IU")
+            .songTitle("Blueming")
+            .similarityScore(BigDecimal.valueOf(0.987))
+            .build();
+
+        // then
+        assertThat(dto.getArtistName()).isEqualTo("IU");
+        assertThat(dto.getSongTitle()).isEqualTo("Blueming");
+        assertThat(dto.getSimilarityScore()).isEqualByComparingTo(BigDecimal.valueOf(0.987));
+        assertThat(dto.isValid()).isTrue();
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 시뮬레이션 - 실제 사용 예제")
+    void shouldSimulateJsonParsing() {
+        // given
+        SimilarSongDto dto = SimilarSongDto.builder()
+            .similarityScore(BigDecimal.valueOf(0.9860607848))
+            .build();
+
+        // when - JSON 파싱을 시뮬레이션
+        dto.setDynamicProperty("Similar Artist 1", "Corey Smith");
+        dto.setDynamicProperty("Similar Song 1", "If I Could Do It Again");
+
+        // then
+        assertThat(dto.getArtistName()).isEqualTo("Corey Smith");
+        assertThat(dto.getSongTitle()).isEqualTo("If I Could Do It Again");
+        assertThat(dto.getSimilarityScore()).isEqualByComparingTo(BigDecimal.valueOf(0.9860607848));
+        assertThat(dto.isValid()).isTrue();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/dto/SongLikeContextTest.java
+++ b/src/test/java/com/example/spotify_song_subject/dto/SongLikeContextTest.java
@@ -1,0 +1,76 @@
+package com.example.spotify_song_subject.dto;
+
+import com.example.spotify_song_subject.domain.Song;
+import com.example.spotify_song_subject.domain.SongLike;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("SongLikeContext 테스트")
+class SongLikeContextTest {
+
+    @Test
+    @DisplayName("likeAdded - 좋아요 추가 컨텍스트 생성")
+    void shouldCreateLikeAddedContext() {
+        // given
+        Song song = mock(Song.class);
+        SongLike songLike = mock(SongLike.class);
+
+        // when
+        SongLikeContext context = SongLikeContext.likeAdded(song, songLike);
+
+        // then
+        assertThat(context.getSong()).isEqualTo(song);
+        assertThat(context.getSongLike()).isEqualTo(songLike);
+        assertThat(context.getTotalLikes()).isNull();
+    }
+
+    @Test
+    @DisplayName("likeAdded - 총 좋아요 수 포함 컨텍스트 생성")
+    void shouldCreateLikeAddedContextWithTotalLikes() {
+        // given
+        Song song = mock(Song.class);
+        SongLike songLike = mock(SongLike.class);
+        Long totalLikes = 100L;
+
+        // when
+        SongLikeContext context = SongLikeContext.likeAdded(song, songLike, totalLikes);
+
+        // then
+        assertThat(context.getSong()).isEqualTo(song);
+        assertThat(context.getSongLike()).isEqualTo(songLike);
+        assertThat(context.getTotalLikes()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("likeRemoved - 좋아요 취소 컨텍스트 생성")
+    void shouldCreateLikeRemovedContext() {
+        // given
+        Song song = mock(Song.class);
+        Long totalLikes = 99L;
+
+        // when
+        SongLikeContext context = SongLikeContext.likeRemoved(song, totalLikes);
+
+        // then
+        assertThat(context.getSong()).isEqualTo(song);
+        assertThat(context.getSongLike()).isNull();
+        assertThat(context.getTotalLikes()).isEqualTo(99L);
+    }
+
+    @Test
+    @DisplayName("setTotalLikes - 총 좋아요 수 업데이트")
+    void shouldUpdateTotalLikes() {
+        // given
+        Song song = mock(Song.class);
+        SongLikeContext context = SongLikeContext.likeRemoved(song, 50L);
+
+        // when
+        context.setTotalLikes(75L);
+
+        // then
+        assertThat(context.getTotalLikes()).isEqualTo(75L);
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/dto/SpotifySongDtoTest.java
+++ b/src/test/java/com/example/spotify_song_subject/dto/SpotifySongDtoTest.java
@@ -1,0 +1,117 @@
+package com.example.spotify_song_subject.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SpotifySongDto 테스트")
+class SpotifySongDtoTest {
+
+    @Test
+    @DisplayName("setAdditionalProperty - 정상적인 속성 추가")
+    void shouldAddAdditionalProperty() {
+        // given
+        SpotifySongDto dto = SpotifySongDto.builder().build();
+
+        // when
+        dto.setAdditionalProperty("customField1", "value1");
+        dto.setAdditionalProperty("customField2", 123);
+
+        // then
+        Map<String, Object> properties = dto.getAdditionalProperties();
+        assertThat(properties)
+            .hasSize(2)
+            .containsEntry("customField1", "value1")
+            .containsEntry("customField2", 123);
+    }
+
+    @Test
+    @DisplayName("setAdditionalProperty - null Map 초기화 처리")
+    void shouldInitializeNullMapWhenAddingProperty() {
+        // given
+        SpotifySongDto dto = new SpotifySongDto();
+        // additionalProperties가 null인 상태
+
+        // when
+        dto.setAdditionalProperty("key", "value");
+
+        // then
+        assertThat(dto.getAdditionalProperties())
+            .isNotNull()
+            .containsEntry("key", "value");
+    }
+
+    @Test
+    @DisplayName("Builder 패턴으로 완전한 DTO 생성")
+    void shouldCreateCompleteDtoWithBuilder() {
+        // given & when
+        SpotifySongDto dto = SpotifySongDto.builder()
+            .artists("BTS, Halsey")
+            .songTitle("Boy With Luv")
+            .albumTitle("MAP OF THE SOUL : PERSONA")
+            .releaseDate("2019-04-12")
+            .tempo(BigDecimal.valueOf(120.5))
+            .popularity(95)
+            .energy(88)
+            .danceability(75)
+            .similarSongs(Collections.emptyList())
+            .build();
+
+        // then
+        assertThat(dto.getArtists()).isEqualTo("BTS, Halsey");
+        assertThat(dto.getSongTitle()).isEqualTo("Boy With Luv");
+        assertThat(dto.getAlbumTitle()).isEqualTo("MAP OF THE SOUL : PERSONA");
+        assertThat(dto.getReleaseDate()).isEqualTo("2019-04-12");
+        assertThat(dto.getTempo()).isEqualByComparingTo(BigDecimal.valueOf(120.5));
+        assertThat(dto.getPopularity()).isEqualTo(95);
+        assertThat(dto.getEnergy()).isEqualTo(88);
+        assertThat(dto.getDanceability()).isEqualTo(75);
+        assertThat(dto.getSimilarSongs()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("빈 DTO 생성 및 null 필드 처리")
+    void shouldHandleEmptyDto() {
+        // given & when
+        SpotifySongDto dto = new SpotifySongDto();
+
+        // then
+        assertThat(dto.getArtists()).isNull();
+        assertThat(dto.getSongTitle()).isNull();
+        assertThat(dto.getAlbumTitle()).isNull();
+        assertThat(dto.getReleaseDate()).isNull();
+        assertThat(dto.getTempo()).isNull();
+        assertThat(dto.getPopularity()).isNull();
+        // additionalProperties는 기본값으로 빈 HashMap이 설정됨
+        assertThat(dto.getAdditionalProperties())
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("활동 적합성 필드 설정")
+    void shouldSetActivitySuitabilityFields() {
+        // given & when
+        SpotifySongDto dto = SpotifySongDto.builder()
+            .goodForParty(85)
+            .goodForWorkStudy(30)
+            .goodForRelaxationMeditation(65)
+            .goodForExercise(90)
+            .goodForRunning(95)
+            .goodForDriving(70)
+            .build();
+
+        // then
+        assertThat(dto.getGoodForParty()).isEqualTo(85);
+        assertThat(dto.getGoodForWorkStudy()).isEqualTo(30);
+        assertThat(dto.getGoodForRelaxationMeditation()).isEqualTo(65);
+        assertThat(dto.getGoodForExercise()).isEqualTo(90);
+        assertThat(dto.getGoodForRunning()).isEqualTo(95);
+        assertThat(dto.getGoodForDriving()).isEqualTo(70);
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/loader/DataInitializationRunnerBehaviorTest.java
+++ b/src/test/java/com/example/spotify_song_subject/loader/DataInitializationRunnerBehaviorTest.java
@@ -40,6 +40,9 @@ class DataInitializationRunnerBehaviorTest {
             spotifyDataStreamReader,
             spotifyDataPersistenceService
         );
+        
+        // parallelBatches 기본값 설정
+        ReflectionTestUtils.setField(dataInitializationRunner, "parallelBatches", 6);
     }
 
     @Test
@@ -165,24 +168,6 @@ class DataInitializationRunnerBehaviorTest {
 
         // then - 스트리밍 처리가 실행되었는지만 검증
         verify(spotifyDataStreamReader, times(1)).streamSpotifyDataInBatches();
-    }
-
-    @Test
-    @DisplayName("데이터 디렉토리가 없으면 예외가 발생한다")
-    void 디렉토리없음_예외발생() {
-        // given
-        Path nonExistentDir = tempDir.resolve("non-existent");
-        ReflectionTestUtils.setField(dataInitializationRunner, "dataDirectory", nonExistentDir.toString());
-
-        // when & then
-        assertThatThrownBy(() -> dataInitializationRunner.onApplicationReady())
-            .isInstanceOf(RuntimeException.class)
-            .hasMessageContaining("Data initialization failed")
-            .hasCauseInstanceOf(IllegalStateException.class);
-
-        // 초기화가 시작도 되지 않음
-        verify(googleDriveDownloader, never()).downloadAndExtractFile();
-        verify(spotifyDataStreamReader, never()).streamSpotifyDataInBatches();
     }
 
     @Test

--- a/src/test/java/com/example/spotify_song_subject/repository/RepositoryTestConfiguration.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/RepositoryTestConfiguration.java
@@ -1,7 +1,10 @@
 package com.example.spotify_song_subject.repository;
 
 import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Repository;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.lang.annotation.ElementType;
@@ -12,11 +15,15 @@ import java.lang.annotation.Target;
 /**
  * Repository 테스트를 위한 공통 설정 어노테이션
  * R2DBC 테스트 환경을 구성하고 H2 인메모리 DB를 사용
- * 데이터베이스 설정은 src/test/resources/application.yml에서 관리됨
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@DataR2dbcTest
+@DataR2dbcTest(includeFilters = {
+    @ComponentScan.Filter(
+        type = FilterType.ANNOTATION,
+        classes = Repository.class
+    )
+})
 @ActiveProfiles("test")
 @Import({TestSchemaInitializer.class, TestR2dbcAuditingConfig.class})
 public @interface RepositoryTestConfiguration {

--- a/src/test/java/com/example/spotify_song_subject/repository/bulk/AlbumBulkRepositoryTest.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/bulk/AlbumBulkRepositoryTest.java
@@ -1,0 +1,162 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.Album;
+import com.example.spotify_song_subject.repository.AlbumRepository;
+import com.example.spotify_song_subject.repository.RepositoryTestConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AlbumBulkRepository 단위 테스트")
+@RepositoryTestConfiguration
+class AlbumBulkRepositoryTest {
+
+    @Autowired
+    private AlbumBulkRepository albumBulkRepository;
+
+    @Autowired
+    private AlbumRepository albumRepository;
+
+    private List<Album> testAlbums;
+
+    @BeforeEach
+    void setUp() {
+        testAlbums = Arrays.asList(
+            Album.of("Album 1", LocalDate.of(2023, 1, 1)),
+            Album.of("Album 2", LocalDate.of(2023, 2, 1)),
+            Album.of("Album 3", LocalDate.of(2023, 3, 1))
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        albumRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("여러 앨범을 일괄 삽입한다")
+    void bulkInsertMultipleAlbums() {
+        // when & then
+        StepVerifier.create(albumBulkRepository.bulkInsert(testAlbums))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was actually inserted
+        StepVerifier.create(albumRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("빈 컬렉션을 삽입하면 0을 반환한다")
+    void bulkInsertEmptyCollection() {
+        // when & then
+        StepVerifier.create(albumBulkRepository.bulkInsert(Collections.emptyList()))
+            .expectNext(0L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("release_date가 null인 앨범도 삽입한다")
+    void bulkInsertAlbumsWithNullReleaseDate() {
+        // given
+        List<Album> albumsWithNullDate = Arrays.asList(
+            Album.of("Album Without Date 1", null),
+            Album.of("Album Without Date 2", null)
+        );
+
+        // when & then
+        StepVerifier.create(albumBulkRepository.bulkInsert(albumsWithNullDate))
+            .expectNext(2L)
+            .verifyComplete();
+
+        // verify data was inserted
+        StepVerifier.create(albumRepository.count())
+            .expectNext(2L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("대량 데이터 일괄 삽입 테스트")
+    void bulkInsertLargeDataSet() {
+        // given
+        List<Album> largeDataSet = new java.util.ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            largeDataSet.add(Album.of("Album " + i, LocalDate.of(2023, 1, 1).plusDays(i)));
+        }
+
+        // when & then
+        StepVerifier.create(albumBulkRepository.bulkInsert(largeDataSet))
+            .expectNext(100L)
+            .verifyComplete();
+
+        // verify all data was inserted
+        StepVerifier.create(albumRepository.count())
+            .expectNext(100L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("중복된 앨범 제목과 날짜도 삽입한다")
+    void bulkInsertDuplicateAlbums() {
+        // given
+        List<Album> duplicateAlbums = Arrays.asList(
+            Album.of("Same Album", LocalDate.of(2023, 1, 1)),
+            Album.of("Same Album", LocalDate.of(2023, 1, 1)),
+            Album.of("Same Album", LocalDate.of(2023, 1, 1))
+        );
+
+        // when & then
+        StepVerifier.create(albumBulkRepository.bulkInsert(duplicateAlbums))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify all duplicates were inserted
+        StepVerifier.create(albumRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+    }
+    
+    @Test
+    @DisplayName("아티스트명을 포함한 앨범을 일괄 삽입한다")
+    void bulkInsertAlbumsWithArtistName() {
+        // given
+        List<Album> albumsWithArtist = Arrays.asList(
+            Album.of("Album 1", LocalDate.of(2023, 1, 1), "Artist A"),
+            Album.of("Album 2", LocalDate.of(2023, 2, 1), "Artist B"),
+            Album.of("Album 3", LocalDate.of(2023, 3, 1), "Artist C")
+        );
+
+        // when & then
+        StepVerifier.create(albumBulkRepository.bulkInsert(albumsWithArtist))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was inserted with artist names
+        StepVerifier.create(albumRepository.findAll())
+            .assertNext(album -> {
+                assertThat(album.getTitle()).isIn("Album 1", "Album 2", "Album 3");
+                assertThat(album.getArtistName()).isNotNull();
+                assertThat(album.getArtistName()).isIn("Artist A", "Artist B", "Artist C");
+            })
+            .assertNext(album -> {
+                assertThat(album.getTitle()).isIn("Album 1", "Album 2", "Album 3");
+                assertThat(album.getArtistName()).isNotNull();
+            })
+            .assertNext(album -> {
+                assertThat(album.getTitle()).isIn("Album 1", "Album 2", "Album 3");
+                assertThat(album.getArtistName()).isNotNull();
+            })
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/repository/bulk/ArtistAlbumBulkRepositoryTest.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/bulk/ArtistAlbumBulkRepositoryTest.java
@@ -1,0 +1,173 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.*;
+import com.example.spotify_song_subject.repository.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ArtistAlbumBulkRepository 단위 테스트")
+
+@RepositoryTestConfiguration
+class ArtistAlbumBulkRepositoryTest {
+
+    @Autowired
+    private ArtistAlbumBulkRepository artistAlbumBulkRepository;
+
+    @Autowired
+    private ArtistAlbumRepository artistAlbumRepository;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
+    private AlbumRepository albumRepository;
+
+    private Long artistId1;
+    private Long artistId2;
+    private Long albumId1;
+    private Long albumId2;
+    private List<ArtistAlbum> testArtistAlbums;
+
+    @BeforeEach
+    void setUp() {
+        // Create test data
+        Artist artist1 = Artist.of("Artist 1");
+        Artist artist2 = Artist.of("Artist 2");
+        artistId1 = artistRepository.save(artist1).block().getId();
+        artistId2 = artistRepository.save(artist2).block().getId();
+
+        Album album1 = Album.of("Album 1", LocalDate.of(2023, 1, 1));
+        Album album2 = Album.of("Album 2", LocalDate.of(2023, 2, 1));
+        albumId1 = albumRepository.save(album1).block().getId();
+        albumId2 = albumRepository.save(album2).block().getId();
+
+        testArtistAlbums = Arrays.asList(
+            ArtistAlbum.builder()
+                .artistId(artistId1)
+                .albumId(albumId1)
+                .build(),
+            ArtistAlbum.builder()
+                .artistId(artistId1)
+                .albumId(albumId2)
+                .build(),
+            ArtistAlbum.builder()
+                .artistId(artistId2)
+                .albumId(albumId1)
+                .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        artistAlbumRepository.deleteAll().block();
+        albumRepository.deleteAll().block();
+        artistRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("여러 아티스트-앨범 관계를 일괄 삽입한다")
+    void bulkInsertMultipleArtistAlbums() {
+        // when & then
+        StepVerifier.create(artistAlbumBulkRepository.bulkInsert(testArtistAlbums))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was actually inserted
+        StepVerifier.create(artistAlbumRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify specific relationships
+        StepVerifier.create(artistAlbumRepository.findAll().filter(aa -> aa.getArtistId().equals(artistId1)).collectList())
+            .assertNext(artistAlbums -> {
+                assertThat(artistAlbums).hasSize(2);
+                assertThat(artistAlbums)
+                    .extracting(ArtistAlbum::getAlbumId)
+                    .containsExactlyInAnyOrder(albumId1, albumId2);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("빈 컬렉션을 삽입하면 0을 반환한다")
+    void bulkInsertEmptyCollection() {
+        // when & then
+        StepVerifier.create(artistAlbumBulkRepository.bulkInsert(Collections.emptyList()))
+            .expectNext(0L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("대량 데이터 일괄 삽입 테스트")
+    void bulkInsertLargeDataSet() {
+        // given
+        List<ArtistAlbum> largeDataSet = new java.util.ArrayList<>();
+
+        // Create more albums for testing
+        for (int i = 0; i < 50; i++) {
+            Album album = Album.of("Album " + i, LocalDate.of(2023, 1, 1).plusDays(i));
+            Long albumId = albumRepository.save(album).block().getId();
+
+            // Create relationships
+            largeDataSet.add(ArtistAlbum.builder()
+                .artistId(artistId1)
+                .albumId(albumId)
+                .build());
+            largeDataSet.add(ArtistAlbum.builder()
+                .artistId(artistId2)
+                .albumId(albumId)
+                .build());
+        }
+
+        // when & then
+        StepVerifier.create(artistAlbumBulkRepository.bulkInsert(largeDataSet))
+            .expectNext(100L)
+            .verifyComplete();
+
+        // verify all data was inserted
+        StepVerifier.create(artistAlbumRepository.count())
+            .expectNext(100L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("중복된 아티스트-앨범 관계도 삽입한다")
+    void bulkInsertDuplicateRelationships() {
+        // given - same artist and album combination multiple times
+        List<ArtistAlbum> duplicates = Arrays.asList(
+            ArtistAlbum.builder()
+                .artistId(artistId1)
+                .albumId(albumId1)
+                .build(),
+            ArtistAlbum.builder()
+                .artistId(artistId1)
+                .albumId(albumId1)
+                .build(),
+            ArtistAlbum.builder()
+                .artistId(artistId1)
+                .albumId(albumId1)
+                .build()
+        );
+
+        // when & then
+        StepVerifier.create(artistAlbumBulkRepository.bulkInsert(duplicates))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify all duplicates were inserted
+        StepVerifier.create(artistAlbumRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/repository/bulk/ArtistBulkRepositoryTest.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/bulk/ArtistBulkRepositoryTest.java
@@ -1,0 +1,104 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.Artist;
+import com.example.spotify_song_subject.repository.ArtistRepository;
+import com.example.spotify_song_subject.repository.RepositoryTestConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.r2dbc.core.DatabaseClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataR2dbcTest
+@Import({RepositoryTestConfiguration.class, ArtistBulkRepository.class})
+class ArtistBulkRepositoryTest {
+
+    @Autowired
+    private ArtistBulkRepository artistBulkRepository;
+    
+    @Autowired
+    private ArtistRepository artistRepository;
+    
+    @Autowired
+    private DatabaseClient databaseClient;
+    
+    @BeforeEach
+    void setUp() {
+        // 테스트 전 데이터 정리
+        databaseClient.sql("DELETE FROM artists")
+            .fetch()
+            .rowsUpdated()
+            .block();
+    }
+    
+    @Test
+    @DisplayName("INSERT IGNORE로 중복된 아티스트는 무시하고 새로운 아티스트만 삽입")
+    void testBulkInsertWithDuplicates() {
+        // Given
+        Artist existingArtist = Artist.of("Artist1");
+        artistRepository.save(existingArtist).block();
+        
+        List<Artist> artistsToInsert = Arrays.asList(
+            Artist.of("Artist1"), // 이미 존재 - 무시됨
+            Artist.of("Artist2"), // 새로운 아티스트
+            Artist.of("Artist3"), // 새로운 아티스트
+            Artist.of("Artist2")  // 같은 배치 내 중복 - 무시됨
+        );
+        
+        // When
+        Mono<Long> result = artistBulkRepository.bulkInsert(artistsToInsert);
+        
+        // Then
+        StepVerifier.create(result)
+            .assertNext(count -> {
+                // H2의 INSERT IGNORE는 실제로 삽입된 행 수를 반환
+                assertThat(count).isEqualTo(2L); // Artist2, Artist3만 삽입
+            })
+            .verifyComplete();
+        
+        // 전체 아티스트 수 확인
+        StepVerifier.create(artistRepository.count())
+            .assertNext(total -> assertThat(total).isEqualTo(3L)) // Artist1, Artist2, Artist3
+            .verifyComplete();
+    }
+    
+    @Test
+    @DisplayName("모든 아티스트가 새로운 경우 전부 삽입")
+    void testBulkInsertAllNew() {
+        // Given
+        List<Artist> artistsToInsert = Arrays.asList(
+            Artist.of("NewArtist1"),
+            Artist.of("NewArtist2"),
+            Artist.of("NewArtist3")
+        );
+        
+        // When
+        Mono<Long> result = artistBulkRepository.bulkInsert(artistsToInsert);
+        
+        // Then
+        StepVerifier.create(result)
+            .assertNext(count -> assertThat(count).isEqualTo(3L))
+            .verifyComplete();
+    }
+    
+    @Test
+    @DisplayName("빈 리스트 처리")
+    void testBulkInsertEmptyList() {
+        // When
+        Mono<Long> result = artistBulkRepository.bulkInsert(List.of());
+        
+        // Then
+        StepVerifier.create(result)
+            .assertNext(count -> assertThat(count).isEqualTo(0L))
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/repository/bulk/ArtistSongBulkRepositoryTest.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/bulk/ArtistSongBulkRepositoryTest.java
@@ -1,0 +1,189 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.*;
+import com.example.spotify_song_subject.repository.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ArtistSongBulkRepository 단위 테스트")
+
+@RepositoryTestConfiguration
+class ArtistSongBulkRepositoryTest {
+
+    @Autowired
+    private ArtistSongBulkRepository artistSongBulkRepository;
+
+    @Autowired
+    private ArtistSongRepository artistSongRepository;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
+    private SongRepository songRepository;
+
+    @Autowired
+    private AlbumRepository albumRepository;
+
+    private Long artistId1;
+    private Long artistId2;
+    private Long songId1;
+    private Long songId2;
+    private List<ArtistSong> testArtistSongs;
+
+    @BeforeEach
+    void setUp() {
+        // Create test data
+        Album album = Album.of("Test Album", LocalDate.of(2023, 1, 1));
+        Long albumId = albumRepository.save(album).block().getId();
+
+        Artist artist1 = Artist.of("Artist 1");
+        Artist artist2 = Artist.of("Artist 2");
+        artistId1 = artistRepository.save(artist1).block().getId();
+        artistId2 = artistRepository.save(artist2).block().getId();
+
+        Song song1 = Song.builder()
+            .title("Song 1")
+            .albumId(albumId)
+            .build();
+        Song song2 = Song.builder()
+            .title("Song 2")
+            .albumId(albumId)
+            .build();
+        songId1 = songRepository.save(song1).block().getId();
+        songId2 = songRepository.save(song2).block().getId();
+
+        testArtistSongs = Arrays.asList(
+            ArtistSong.builder()
+                .artistId(artistId1)
+                .songId(songId1)
+                .build(),
+            ArtistSong.builder()
+                .artistId(artistId1)
+                .songId(songId2)
+                .build(),
+            ArtistSong.builder()
+                .artistId(artistId2)
+                .songId(songId1)
+                .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        artistSongRepository.deleteAll().block();
+        songRepository.deleteAll().block();
+        artistRepository.deleteAll().block();
+        albumRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("여러 아티스트-노래 관계를 일괄 삽입한다")
+    void bulkInsertMultipleArtistSongs() {
+        // when & then
+        StepVerifier.create(artistSongBulkRepository.bulkInsert(testArtistSongs))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was actually inserted
+        StepVerifier.create(artistSongRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify specific relationships
+        StepVerifier.create(artistSongRepository.findAll().filter(as -> as.getArtistId().equals(artistId1)).collectList())
+            .assertNext(artistSongs -> {
+                assertThat(artistSongs).hasSize(2);
+                assertThat(artistSongs)
+                    .extracting(ArtistSong::getSongId)
+                    .containsExactlyInAnyOrder(songId1, songId2);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("빈 컬렉션을 삽입하면 0을 반환한다")
+    void bulkInsertEmptyCollection() {
+        // when & then
+        StepVerifier.create(artistSongBulkRepository.bulkInsert(Collections.emptyList()))
+            .expectNext(0L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("대량 데이터 일괄 삽입 테스트")
+    void bulkInsertLargeDataSet() {
+        // given
+        List<ArtistSong> largeDataSet = new java.util.ArrayList<>();
+
+        // Create more songs for testing
+        for (int i = 0; i < 50; i++) {
+            Song song = Song.builder()
+                .title("Song " + i)
+                .albumId(songRepository.findByTitle("Song 1").next().block().getAlbumId())
+                .build();
+            Long songId = songRepository.save(song).block().getId();
+
+            // Create relationships
+            largeDataSet.add(ArtistSong.builder()
+                .artistId(artistId1)
+                .songId(songId)
+                .build());
+            largeDataSet.add(ArtistSong.builder()
+                .artistId(artistId2)
+                .songId(songId)
+                .build());
+        }
+
+        // when & then
+        StepVerifier.create(artistSongBulkRepository.bulkInsert(largeDataSet))
+            .expectNext(100L)
+            .verifyComplete();
+
+        // verify all data was inserted (plus initial test data)
+        StepVerifier.create(artistSongRepository.count())
+            .expectNext(100L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("중복된 아티스트-노래 관계도 삽입한다")
+    void bulkInsertDuplicateRelationships() {
+        // given - same artist and song combination multiple times
+        List<ArtistSong> duplicates = Arrays.asList(
+            ArtistSong.builder()
+                .artistId(artistId1)
+                .songId(songId1)
+                .build(),
+            ArtistSong.builder()
+                .artistId(artistId1)
+                .songId(songId1)
+                .build(),
+            ArtistSong.builder()
+                .artistId(artistId1)
+                .songId(songId1)
+                .build()
+        );
+
+        // when & then
+        StepVerifier.create(artistSongBulkRepository.bulkInsert(duplicates))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify all duplicates were inserted
+        StepVerifier.create(artistSongRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/repository/bulk/SimilarSongBulkRepositoryTest.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/bulk/SimilarSongBulkRepositoryTest.java
@@ -1,0 +1,253 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.*;
+import com.example.spotify_song_subject.repository.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SimilarSongBulkRepository 단위 테스트")
+
+@RepositoryTestConfiguration
+class SimilarSongBulkRepositoryTest {
+
+    @Autowired
+    private SimilarSongBulkRepository similarSongBulkRepository;
+
+    @Autowired
+    private SimilarSongRepository similarSongRepository;
+
+    @Autowired
+    private SongRepository songRepository;
+
+    @Autowired
+    private AlbumRepository albumRepository;
+
+    private Long songId1;
+    private Long songId2;
+    private List<SimilarSong> testSimilarSongs;
+
+    @BeforeEach
+    void setUp() {
+        // Create test data
+        Album album = Album.of("Test Album", LocalDate.of(2023, 1, 1));
+        Long albumId = albumRepository.save(album).block().getId();
+
+        Song song1 = Song.builder()
+            .title("Song 1")
+            .albumId(albumId)
+            .build();
+        Song song2 = Song.builder()
+            .title("Song 2")
+            .albumId(albumId)
+            .build();
+        songId1 = songRepository.save(song1).block().getId();
+        songId2 = songRepository.save(song2).block().getId();
+
+        testSimilarSongs = Arrays.asList(
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Similar Artist 1")
+                .similarSongTitle("Similar Song 1")
+                .similarityScore(new BigDecimal("0.95"))
+                .build(),
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Similar Artist 2")
+                .similarSongTitle("Similar Song 2")
+                .similarityScore(new BigDecimal("0.85"))
+                .build(),
+            SimilarSong.builder()
+                .songId(songId2)
+                .similarArtistName("Similar Artist 3")
+                .similarSongTitle("Similar Song 3")
+                .similarityScore(new BigDecimal("0.75"))
+                .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        similarSongRepository.deleteAll().block();
+        songRepository.deleteAll().block();
+        albumRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("여러 유사 노래 관계를 일괄 삽입한다")
+    void bulkInsertMultipleSimilarSongs() {
+        // when & then
+        StepVerifier.create(similarSongBulkRepository.bulkInsert(testSimilarSongs))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was actually inserted
+        StepVerifier.create(similarSongRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify specific relationships
+        StepVerifier.create(similarSongRepository.findBySongId(songId1).collectList())
+            .assertNext(similarSongs -> {
+                assertThat(similarSongs).hasSize(2);
+                assertThat(similarSongs)
+                    .extracting(song -> song.getSimilarityScore().stripTrailingZeros())
+                    .containsExactlyInAnyOrder(new BigDecimal("0.95"), new BigDecimal("0.85"));
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("빈 컬렉션을 삽입하면 0을 반환한다")
+    void bulkInsertEmptyCollection() {
+        // when & then
+        StepVerifier.create(similarSongBulkRepository.bulkInsert(Collections.emptyList()))
+            .expectNext(0L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("0 점수를 가진 데이터도 삽입한다")
+    void bulkInsertWithZeroScore() {
+        // given
+        List<SimilarSong> songsWithZeroScore = Arrays.asList(
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Artist")
+                .similarSongTitle("Song")
+                .similarityScore(BigDecimal.ZERO)  // 0 score
+                .build(),
+            SimilarSong.builder()
+                .songId(songId2)
+                .similarArtistName("Another Artist")
+                .similarSongTitle("Another Song")
+                .similarityScore(new BigDecimal("0.0"))
+                .build()
+        );
+
+        // when & then
+        StepVerifier.create(similarSongBulkRepository.bulkInsert(songsWithZeroScore))
+            .expectNext(2L)
+            .verifyComplete();
+
+        // verify data was inserted
+        StepVerifier.create(similarSongRepository.count())
+            .expectNext(2L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("대량 데이터 일괄 삽입 테스트")
+    void bulkInsertLargeDataSet() {
+        // given
+        List<SimilarSong> largeDataSet = new java.util.ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            largeDataSet.add(
+                SimilarSong.builder()
+                    .songId(i % 2 == 0 ? songId1 : songId2)
+                    .similarArtistName("Artist " + i)
+                    .similarSongTitle("Song " + i)
+                    .similarityScore(new BigDecimal(0.5 + (i * 0.005)))
+                    .build()
+            );
+        }
+
+        // when & then
+        StepVerifier.create(similarSongBulkRepository.bulkInsert(largeDataSet))
+            .expectNext(100L)
+            .verifyComplete();
+
+        // verify all data was inserted
+        StepVerifier.create(similarSongRepository.count())
+            .expectNext(100L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("동일한 유사 노래 정보도 중복 삽입한다")
+    void bulkInsertDuplicateSimilarSongs() {
+        // given - same similar song multiple times
+        List<SimilarSong> duplicates = Arrays.asList(
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Same Artist")
+                .similarSongTitle("Same Song")
+                .similarityScore(new BigDecimal("0.9"))
+                .build(),
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Same Artist")
+                .similarSongTitle("Same Song")
+                .similarityScore(new BigDecimal("0.9"))
+                .build(),
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Same Artist")
+                .similarSongTitle("Same Song")
+                .similarityScore(new BigDecimal("0.9"))
+                .build()
+        );
+
+        // when & then
+        StepVerifier.create(similarSongBulkRepository.bulkInsert(duplicates))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify all duplicates were inserted
+        StepVerifier.create(similarSongRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("특수 문자가 포함된 아티스트명과 노래 제목도 삽입한다")
+    void bulkInsertWithSpecialCharacters() {
+        // given
+        List<SimilarSong> specialCharSongs = Arrays.asList(
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Artist's Name")
+                .similarSongTitle("Song's Title")
+                .similarityScore(new BigDecimal("0.8"))
+                .build(),
+            SimilarSong.builder()
+                .songId(songId2)
+                .similarArtistName("아티스트")
+                .similarSongTitle("한글 제목")
+                .similarityScore(new BigDecimal("0.7"))
+                .build(),
+            SimilarSong.builder()
+                .songId(songId1)
+                .similarArtistName("Artist & Co.")
+                .similarSongTitle("Rock & Roll")
+                .similarityScore(new BigDecimal("0.9"))
+                .build()
+        );
+
+        // when & then
+        StepVerifier.create(similarSongBulkRepository.bulkInsert(specialCharSongs))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was inserted correctly
+        StepVerifier.create(similarSongRepository.findBySongId(songId1).collectList())
+            .assertNext(similarSongs -> {
+                assertThat(similarSongs).hasSize(2);
+                assertThat(similarSongs)
+                    .extracting(SimilarSong::getSimilarArtistName)
+                    .containsExactlyInAnyOrder("Artist's Name", "Artist & Co.");
+            })
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/example/spotify_song_subject/repository/bulk/SongBulkRepositoryTest.java
+++ b/src/test/java/com/example/spotify_song_subject/repository/bulk/SongBulkRepositoryTest.java
@@ -1,0 +1,162 @@
+package com.example.spotify_song_subject.repository.bulk;
+
+import com.example.spotify_song_subject.domain.Album;
+import com.example.spotify_song_subject.domain.Song;
+import com.example.spotify_song_subject.repository.AlbumRepository;
+import com.example.spotify_song_subject.repository.RepositoryTestConfiguration;
+import com.example.spotify_song_subject.repository.SongRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SongBulkRepository 단위 테스트")
+
+@RepositoryTestConfiguration
+class SongBulkRepositoryTest {
+
+    @Autowired
+    private SongBulkRepository songBulkRepository;
+
+    @Autowired
+    private SongRepository songRepository;
+
+    @Autowired
+    private AlbumRepository albumRepository;
+
+    private Long albumId;
+    private List<Song> testSongs;
+
+    @BeforeEach
+    void setUp() {
+        // Create an album first for foreign key reference
+        Album album = Album.of("Test Album", LocalDate.of(2023, 1, 1));
+        albumId = albumRepository.save(album).block().getId();
+
+        testSongs = Arrays.asList(
+            createSong("Song 1", albumId, 180, "Rock", new BigDecimal("0.8")),
+            createSong("Song 2", albumId, 200, "Pop", new BigDecimal("0.7")),
+            createSong("Song 3", albumId, 220, "Jazz", new BigDecimal("0.6"))
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        songRepository.deleteAll().block();
+        albumRepository.deleteAll().block();
+    }
+
+    @Test
+    @DisplayName("여러 노래를 일괄 삽입한다")
+    void bulkInsertMultipleSongs() {
+        // when & then
+        StepVerifier.create(songBulkRepository.bulkInsert(testSongs))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify data was actually inserted
+        StepVerifier.create(songRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify specific song data
+        StepVerifier.create(songRepository.findByTitle("Song 1").next())
+            .assertNext(song -> {
+                assertThat(song).isNotNull();
+                assertThat(song.getTitle()).isEqualTo("Song 1");
+                assertThat(song.getAlbumId()).isEqualTo(albumId);
+            })
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("빈 컬렉션을 삽입하면 0을 반환한다")
+    void bulkInsertEmptyCollection() {
+        // when & then
+        StepVerifier.create(songBulkRepository.bulkInsert(Collections.emptyList()))
+            .expectNext(0L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("nullable 필드가 null인 노래도 삽입한다")
+    void bulkInsertSongsWithNullFields() {
+        // given
+        List<Song> songsWithNulls = Arrays.asList(
+            createSong("Song with nulls 1", albumId, null, null, null),
+            createSong("Song with nulls 2", albumId, null, null, null)
+        );
+
+        // when & then
+        StepVerifier.create(songBulkRepository.bulkInsert(songsWithNulls))
+            .expectNext(2L)
+            .verifyComplete();
+
+        // verify data was inserted
+        StepVerifier.create(songRepository.count())
+            .expectNext(2L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("대량 데이터 일괄 삽입 테스트")
+    void bulkInsertLargeDataSet() {
+        // given
+        List<Song> largeDataSet = new java.util.ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            largeDataSet.add(createSong("Song " + i, albumId, 180 + i, "Genre " + i, new BigDecimal(0.5 + (i * 0.001))));
+        }
+
+        // when & then
+        StepVerifier.create(songBulkRepository.bulkInsert(largeDataSet))
+            .expectNext(100L)
+            .verifyComplete();
+
+        // verify all data was inserted
+        StepVerifier.create(songRepository.count())
+            .expectNext(100L)
+            .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("동일한 제목의 노래도 삽입한다")
+    void bulkInsertDuplicateTitles() {
+        // given
+        List<Song> duplicateSongs = Arrays.asList(
+            createSong("Same Song", albumId, 180, "Rock", new BigDecimal("0.8")),
+            createSong("Same Song", albumId, 180, "Rock", new BigDecimal("0.8")),
+            createSong("Same Song", albumId, 180, "Rock", new BigDecimal("0.8"))
+        );
+
+        // when & then
+        StepVerifier.create(songBulkRepository.bulkInsert(duplicateSongs))
+            .expectNext(3L)
+            .verifyComplete();
+
+        // verify all duplicates were inserted
+        StepVerifier.create(songRepository.count())
+            .expectNext(3L)
+            .verifyComplete();
+    }
+
+    private Song createSong(String title, Long albumId, Integer duration, String genre, BigDecimal valence) {
+        Song song = Song.builder()
+            .title(title)
+            .albumId(albumId)
+            .energy(duration)  // Using energy field as duration proxy
+            .genre(genre)
+            .tempo(valence)  // Using tempo field as valence proxy
+            .build();
+        return song;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -54,6 +54,8 @@ data:
     size: 100
   buffer:
     size: 1024
+  parallel:
+    batches: 6  # 동시에 처리할 배치 수
 
 # Google Drive 설정 (테스트용)
 google:


### PR DESCRIPTION
### 작업 내용

1. Bulk Insert 구현을 통한 데이터 저장 성능 개선
- 각 도메인별 Bulk Repository, Bulk Processor 구현 (Song, Artist, Album, ArtistSong, ArtistAlbum)
- 단일 INSERT 대신 배치 INSERT로 DB 작업 최적화

2. API 개선
- 연도별/아티스트별 앨범 수 조회 API 개선 페이징 처리 추가로 대용량 결과 처리 가능
- 페이징 유틸리티 클래스 추가

3. 테스트 커버리지 강화
- Bulk Repository 단위 테스트 추가
- Batch Processor 통합 테스트 구현
- DTO 레이어 단위 테스트 추가
- 테스트 환경 구성 개선

<br>
<hr>

### 체크리스트

✅ 체크리스트
- [x] 모든 단위 테스트 통과
- [x] 성능 개선 완료
- [ ] 문서화 업데이트

<br>
<hr>

### 기타


<br>
<hr>
